### PR TITLE
Include adapter metadata in report payload

### DIFF
--- a/judoscale/celery/__init__.py
+++ b/judoscale/celery/__init__.py
@@ -1,9 +1,11 @@
 import time
 
 from celery import Celery
+from celery import __version__ as celery_version
 from celery.signals import before_task_publish
 
 from judoscale.celery.collector import CeleryMetricsCollector
+from judoscale.core.adapter import Adapter, AdapterInfo
 from judoscale.core.config import config as judoconfig
 from judoscale.core.reporter import reporter
 
@@ -18,6 +20,11 @@ def judoscale_celery(celery: Celery, extra_config: dict = {}) -> None:
 
     judoconfig.merge(extra_config)
     collector = CeleryMetricsCollector(config=judoconfig, broker=celery)
+    adapter = Adapter(
+        identifier="judoscale-celery",
+        adapter_info=AdapterInfo(platform_version=celery_version),
+        metrics_collector=collector,
+    )
 
-    reporter.add_collector(collector)
+    reporter.add_adapter(adapter)
     reporter.ensure_running()

--- a/judoscale/core/adapter.py
+++ b/judoscale/core/adapter.py
@@ -1,0 +1,29 @@
+from dataclasses import asdict, dataclass
+from typing import Optional
+
+from pkg_resources import get_distribution
+
+from judoscale.core.metrics_collectors import Collector
+
+JUDOSCALE_VERSION = get_distribution("judoscale-python").version
+
+
+@dataclass
+class AdapterInfo:
+    """Information about the adapter"""
+
+    platform_version: str
+    adapter_version: str = JUDOSCALE_VERSION
+
+
+@dataclass
+class Adapter:
+    """Adapter information and optional metrics collector"""
+
+    identifier: str
+    adapter_info: AdapterInfo
+    metrics_collector: Optional[Collector] = None
+
+    @property
+    def as_tuple(self):
+        return (self.identifier, asdict(self.adapter_info))

--- a/judoscale/django/apps.py
+++ b/judoscale/django/apps.py
@@ -3,7 +3,7 @@ import logging
 from django.apps import AppConfig
 from django.conf import settings
 
-from judoscale.core.config import config
+from judoscale.core.config import config as judoconfig
 from judoscale.core.reporter import reporter
 
 logger = logging.getLogger(__name__)
@@ -14,9 +14,9 @@ class JudoscaleDjangoConfig(AppConfig):
     verbose_name = "Judoscale (Django)"
 
     def ready(self):
-        config.merge(getattr(settings, "JUDOSCALE", {}))
+        judoconfig.merge(getattr(settings, "JUDOSCALE", {}))
 
-        if config.api_base_url is None:
+        if judoconfig.api_base_url is None:
             logger.info("Not activated - No API URL provided")
             return
 

--- a/judoscale/django/middleware.py
+++ b/judoscale/django/middleware.py
@@ -1,4 +1,7 @@
-from judoscale.core.config import config
+from django import get_version as django_version
+
+from judoscale.core.adapter import Adapter, AdapterInfo
+from judoscale.core.config import config as judoconfig
 from judoscale.core.metric import Metric
 from judoscale.core.metrics_collectors import WebMetricsCollector
 from judoscale.core.reporter import reporter
@@ -9,8 +12,13 @@ class RequestQueueTimeMiddleware:
 
     def __init__(self, get_response):
         self.get_response = get_response
-        self.collector = WebMetricsCollector(config)
-        reporter.add_collector(self.collector)
+        self.collector = WebMetricsCollector(judoconfig)
+        adapter = Adapter(
+            identifier="judoscale-django",
+            adapter_info=AdapterInfo(platform_version=django_version()),
+            metrics_collector=self.collector,
+        )
+        reporter.add_adapter(adapter)
 
     def __call__(self, request):
         request_start_header = request.META.get("HTTP_X_REQUEST_START", "")

--- a/judoscale/flask/judoscale.py
+++ b/judoscale/flask/judoscale.py
@@ -1,5 +1,10 @@
+from typing import Optional
+
+from flask import Flask
+from flask import __version__ as flask_version
 from flask import request
 
+from judoscale.core.adapter import Adapter, AdapterInfo
 from judoscale.core.config import config as judoconfig
 from judoscale.core.metric import Metric
 from judoscale.core.metrics_collectors import WebMetricsCollector
@@ -18,13 +23,18 @@ def store_request_metrics(collector: WebMetricsCollector):
 
 
 class Judoscale:
-    def __init__(self, app=None):
+    def __init__(self, app: Optional[Flask] = None):
         if app is not None:
             self.init_app(app)
 
-    def init_app(self, app):
+    def init_app(self, app: Flask):
         judoconfig.merge(app.config.get("JUDOSCALE", {}))
         collector = WebMetricsCollector(judoconfig)
-        reporter.add_collector(collector)
+        adapter = Adapter(
+            identifier="judoscale-flask",
+            adapter_info=AdapterInfo(platform_version=flask_version),
+            metrics_collector=collector,
+        )
+        reporter.add_adapter(adapter)
         reporter.ensure_running()
         app.before_request(store_request_metrics(collector))

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -2,6 +2,7 @@ import unittest
 from datetime import datetime
 from unittest import TestCase
 
+from judoscale.core.adapter import Adapter, AdapterInfo
 from judoscale.core.config import config
 from judoscale.core.metric import Metric
 from judoscale.core.metrics_collectors import WebMetricsCollector
@@ -24,19 +25,48 @@ class TestReporter(TestCase):
         assert len(report["metrics"]) == 1
         assert report["metrics"][0] == (1355314320, 123, "test", None)
 
-    def test_add_collector(self):
-        collector_instance = WebMetricsCollector(config)
-        self.reporter.add_collector(collector_instance)
-        assert self.reporter.collectors == [collector_instance]
+    def test_no_explicity_adapter(self):
+        assert len(self.reporter.adapters) == 1
+        assert self.reporter.adapters[0].identifier == "judoscale-python"
+
+    def test_add_adapter_no_collector(self):
+        adapter = Adapter(
+            identifier="test",
+            adapter_info=AdapterInfo(platform_version="0.0.0"),
+            metrics_collector=None,
+        )
+        self.reporter.add_adapter(adapter)
+        assert adapter in self.reporter.adapters
+        assert self.reporter.collectors == []
+
+    def test_add_adapter_with_collector(self):
+        adapter = Adapter(
+            identifier="test",
+            adapter_info=AdapterInfo(platform_version="0.0.0"),
+            metrics_collector=WebMetricsCollector(config),
+        )
+        self.reporter.add_adapter(adapter)
+        assert adapter in self.reporter.adapters
+        assert self.reporter.collectors == [adapter.metrics_collector]
 
     def test_all_metrics_empty(self):
         assert self.reporter.all_metrics == []
 
     def test_all_metrics_not_empty(self):
         collector_instance_1 = WebMetricsCollector(config)
+        adapter_instance_1 = Adapter(
+            identifier="test",
+            adapter_info=AdapterInfo(platform_version="0.0.0"),
+            metrics_collector=collector_instance_1,
+        )
         collector_instance_2 = WebMetricsCollector(config)
-        self.reporter.add_collector(collector_instance_1)
-        self.reporter.add_collector(collector_instance_2)
+        adapter_instance_2 = Adapter(
+            identifier="test",
+            adapter_info=AdapterInfo(platform_version="0.0.0"),
+            metrics_collector=collector_instance_2,
+        )
+        self.reporter.add_adapter(adapter_instance_1)
+        self.reporter.add_adapter(adapter_instance_2)
         collector_instance_1.add(Metric(measurement="qt", timestamp=0, value=0))
         collector_instance_2.add(Metric(measurement="qt", timestamp=0, value=0))
         assert len(self.reporter.all_metrics) == 2


### PR DESCRIPTION
This PR introduces a very thin abstraction called `Adapter`. An Adapter wraps metadata about the Judoscale library version and the language/framework version. It also wraps the metrics collector for each integration, as needed.

Adapters are registered with the Reporter which sends metrics as before and also now includes adapter metadata under the `"adapters"` key.

Example payload from the Celery sample app:

```json
{
    "dyno": "web.1",
    "pid": 85868,
    "config": {
        "log_level": "DEBUG",
        "report_interval_seconds": 15
    },
    "adapters": {
        "judoscale-python": {
            "platform_version": "3.10.4",
            "adapter_version": "0.1.1"
        },
        "judoscale-celery": {
            "platform_version": "5.2.7",
            "adapter_version": "0.1.1"
        },
        "judoscale-flask": {
            "platform_version": "2.2.2",
            "adapter_version": "0.1.1"
        }
    },
    "metrics": [
        [
            1676292771,
            531063,
            "queue_time",
            "high"
        ],
        [
            1676292771,
            532618,
            "queue_time",
            "low"
        ],
        [
            1676292757,
            1,
            "queue_time",
            null
        ],
        [
            1676292757,
            6,
            "queue_time",
            null
        ]
    ]
}
```