### PR TITLE
Handle ambiguous timestamp values in X-Request-Start

### DIFF
--- a/judoscale/core/metric.py
+++ b/judoscale/core/metric.py
@@ -1,14 +1,9 @@
-import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Optional, Tuple
 
 from judoscale.core.logger import logger
-
-nanoseconds = re.compile(r"^\d{19}$")
-milliseconds = re.compile(r"^\d{13}$")
-fractional_seconds = re.compile(r"^\d{10}.\d{3}$")
 
 # Adapted from https://github.com/scoutapp/scout_apm_python/blob/86d14920a59a7a3b5dfffe680586646ee29bdd7a/src/scout_apm/core/web_requests.py#L139-L162 # noqa: E501
 # Cutoff epoch is used for determining ambiguous timestamp boundaries

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,5 +35,8 @@ class TestMetricsForWeb(unittest.TestCase):
         # time.sleep() inaccuracy and the time it takes to run the test.
         self.assertAlmostEqual(metric.value, 20, delta=10)
 
+    def test_negative_value(self):
+        self.assertIsNone(Metric.for_web("t=-123456789"))
+
     def test_garbage_value(self):
         self.assertIsNone(Metric.for_web("abc."))

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,15 @@ class TestMetricsForWeb(unittest.TestCase):
         # time.sleep() inaccuracy and the time it takes to run the test.
         self.assertAlmostEqual(metric.value, 20, delta=10)
 
+    def test_render_metrics(self):
+        # Render timestamp is in integer nanoseconds
+        render_timestamp = str(time.time_ns())
+        time.sleep(0.02)
+        metric = Metric.for_web(render_timestamp)
+        # Allow metric value to be within 10ms of 20ms to account for
+        # time.sleep() inaccuracy and the time it takes to run the test.
+        self.assertAlmostEqual(metric.value, 20, delta=10)
+
     def test_nginx_metrics(self):
         # Nginx timestamp is in seconds with millisecond resolution (3dp).
         #
@@ -25,3 +34,6 @@ class TestMetricsForWeb(unittest.TestCase):
         # Allow metric value to be within 10ms of 20ms to account for
         # time.sleep() inaccuracy and the time it takes to run the test.
         self.assertAlmostEqual(metric.value, 20, delta=10)
+
+    def test_garbage_value(self):
+        self.assertIsNone(Metric.for_web("abc."))


### PR DESCRIPTION
Add nanosecond and microsecond support in `X-Request-Start`.