### PR TITLE
feat: Add support for tracking busy jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,13 @@ An example configuration dictionary accepted by `extra_config`:
         # Specify a list of known queues to report metrics for.
         # MAX_QUEUES is still honoured.
         # Defaults to empty list (report metrics for discovered queues).
-        "QUEUES": []
+        "QUEUES": [],
+
+        # Enable or disable (default) tracking how many jobs are currently being
+        # processed in each queue.
+        # This allows Judoscale to avoid downscaling workers that are executing jobs.
+        # See documentation: https://judoscale.com/docs/long-running-jobs-ruby#enable-long-running-job-support-in-the-dashboard
+        "TRACK_BUSY_JOBS": False,
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,17 @@ An example configuration dictionary accepted by `extra_config`:
         # Specify a list of known queues to report metrics for.
         # MAX_QUEUES is still honoured.
         # Defaults to empty list (report metrics for discovered queues).
-        "QUEUES": []
+        "QUEUES": [],
+
+        # Enable or disable (default) tracking how many jobs are currently being
+        # processed in each queue.
+        # This allows Judoscale to avoid downscaling workers that are executing jobs.
+        # See documentation: https://judoscale.com/docs/long-running-jobs-ruby#enable-long-running-job-support-in-the-dashboard
+        # NOTE: This option requires workers to have unique names. If you are running
+        # multiple Celery workers on the same machine, make sure to give each
+        # worker a distinct name.
+        # More information: https://docs.celeryq.dev/en/stable/userguide/workers.html#starting-the-worker
+        "TRACK_BUSY_JOBS": False,
     }
 }
 ```

--- a/judoscale/core/metric.py
+++ b/judoscale/core/metric.py
@@ -107,3 +107,24 @@ class Metric:
         metric = Metric.new(start_ms=int(oldest_job_ts * 1000), queue_name=queue_name)
         logger.debug(f"queue_name={queue_name}, queue_time={metric.value}ms")
         return metric
+
+    @classmethod
+    def for_busy_queue(cls, queue_name: str, busy_jobs: int) -> "Metric":
+        """
+        Log and return a Metric instance for the number of jobs being processed
+        for a given queue.
+
+        queue_name:
+            The name of the queue.
+
+        busy_jobs:
+            The number of jobs being processed for the given queue.
+        """
+        metric = Metric(
+            measurement="busy",
+            queue_name=queue_name,
+            value=busy_jobs,
+            timestamp=time.time(),
+        )
+        logger.debug(f"queue_name={queue_name}, busy_jobs={metric.value}")
+        return metric

--- a/judoscale/rq/collector.py
+++ b/judoscale/rq/collector.py
@@ -57,16 +57,10 @@ class RQMetricsCollector(JobMetricsCollector):
 
         for queue in queues:
             if self.adapter_config["TRACK_BUSY_JOBS"]:
-                logger.debug(
-                    f"Queue {queue.name} has {queue.count} job(s) and "
-                    f"{queue.started_job_registry.count} busy job(s)."
-                )
                 metrics.append(
-                    Metric(
-                        timestamp=time.time(),
-                        value=queue.started_job_registry.count,
+                    Metric.for_busy_queue(
                         queue_name=queue.name,
-                        measurement="busy",
+                        busy_jobs=queue.started_job_registry.count,
                     )
                 )
 

--- a/judoscale/rq/collector.py
+++ b/judoscale/rq/collector.py
@@ -15,6 +15,7 @@ DEFAULTS = {
     "ENABLED": True,
     "MAX_QUEUES": 20,
     "QUEUES": [],
+    "TRACK_BUSY_JOBS": False,
 }
 
 
@@ -53,7 +54,22 @@ class RQMetricsCollector(JobMetricsCollector):
 
         logger.debug(f"Collecting metrics for queues {list(self.queues)}")
         queues = [Queue(name=q, connection=self.redis) for q in self.queues]
+
         for queue in queues:
+            if self.adapter_config["TRACK_BUSY_JOBS"]:
+                logger.debug(
+                    f"Queue {queue.name} has {queue.count} job(s) and "
+                    f"{queue.started_job_registry.count} busy job(s)."
+                )
+                metrics.append(
+                    Metric(
+                        timestamp=time.time(),
+                        value=queue.started_job_registry.count,
+                        queue_name=queue.name,
+                        measurement="busy",
+                    )
+                )
+
             if job := self.oldest_job(queue):
                 if job.enqueued_at is not None:
                     # RQ stores `enqueued_at` as a naive datetime object, which

--- a/sample-apps/django_celery_sample/Procfile.heroku
+++ b/sample-apps/django_celery_sample/Procfile.heroku
@@ -3,5 +3,5 @@ proxy: npx judoscale-adapter-proxy-server
 
 # Run with --noreload to avoid multiple server processes (and multiple Judoscale reporters)
 web: DYNO=web.1 poetry run gunicorn django_celery_sample.wsgi:application --preload
-worker: DYNO=worker.1 poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q low
-worker_high: DYNO=worker_high.1 poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q high
+worker: DYNO=worker.1 poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q low -n worker
+worker_high: DYNO=worker_high.1 poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q high -n worker_high

--- a/sample-apps/django_celery_sample/Procfile.render
+++ b/sample-apps/django_celery_sample/Procfile.render
@@ -3,5 +3,5 @@ proxy: npx judoscale-adapter-proxy-server
 
 # Run with --noreload to avoid multiple server processes (and multiple Judoscale reporters)
 web: RENDER_SERVICE_ID=srv-123 RENDER_INSTANCE_ID=srv-123-abc-456 RENDER_SERVICE_TYPE=web poetry run gunicorn django_celery_sample.wsgi:application --preload
-worker: RENDER_SERVICE_ID=wrk-123 RENDER_INSTANCE_ID=wrk-123-abc-456 RENDER_SERVICE_TYPE=worker poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q low
-worker_high: RENDER_SERVICE_ID=wrk-456 RENDER_INSTANCE_ID=wrk-456-abc-789 RENDER_SERVICE_TYPE=worker poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q high
+worker: RENDER_SERVICE_ID=wrk-123 RENDER_INSTANCE_ID=wrk-123-abc-456 RENDER_SERVICE_TYPE=worker poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q low -n worker
+worker_high: RENDER_SERVICE_ID=wrk-456 RENDER_INSTANCE_ID=wrk-456-abc-789 RENDER_SERVICE_TYPE=worker poetry run celery -A django_celery_sample worker -c 1 --loglevel=INFO -Q high -n worker_high

--- a/sample-apps/flask_celery_sample/Procfile.heroku
+++ b/sample-apps/flask_celery_sample/Procfile.heroku
@@ -2,5 +2,5 @@
 proxy: npx judoscale-adapter-proxy-server
 
 web: DYNO=web.1 poetry run gunicorn --preload 'app.app:create_app()'
-worker: DYNO=worker.1 poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q low
-worker_high: DYNO=worker_high.1 poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q high
+worker: DYNO=worker.1 poetry run celery -A app.tasks worker -c 3 --loglevel=INFO -Q low -n worker
+worker_high: DYNO=worker_high.1 poetry run celery -A app.tasks worker -c 5 --loglevel=INFO -Q high -n worker_high

--- a/sample-apps/flask_celery_sample/Procfile.render
+++ b/sample-apps/flask_celery_sample/Procfile.render
@@ -2,5 +2,5 @@
 proxy: npx judoscale-adapter-proxy-server
 
 web: RENDER_SERVICE_ID=srv-123 RENDER_INSTANCE_ID=srv-123-abc-456 RENDER_SERVICE_TYPE=web poetry run gunicorn --preload 'app.app:create_app()'
-worker: RENDER_SERVICE_ID=wrk-123 RENDER_INSTANCE_ID=wrk-123-abc-456 RENDER_SERVICE_TYPE=worker poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q low
-worker_high: RENDER_SERVICE_ID=wrk-456 RENDER_INSTANCE_ID=wrk-456-abc-789 RENDER_SERVICE_TYPE=worker poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q high
+worker: RENDER_SERVICE_ID=wrk-123 RENDER_INSTANCE_ID=wrk-123-abc-456 RENDER_SERVICE_TYPE=worker poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q low -n worker
+worker_high: RENDER_SERVICE_ID=wrk-456 RENDER_INSTANCE_ID=wrk-456-abc-789 RENDER_SERVICE_TYPE=worker poetry run celery -A app.tasks worker -c 1 --loglevel=INFO -Q high -n worker_high

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -105,6 +105,7 @@ class TestCeleryMetricsCollector:
             "ENABLED": False,
             "QUEUES": ["foo", "bar"],
             "MAX_QUEUES": 20,
+            "TRACK_BUSY_JOBS": False,
         }
 
     def test_incorrect_driver(self, worker_1, celery):
@@ -175,6 +176,37 @@ class TestCeleryMetricsCollector:
 
         collector = CeleryMetricsCollector(worker_1, celery)
         assert len(collector.collect()) == 2
+
+    def test_collect_with_busy_jobs(self, worker_1, celery, monkeypatch):
+        now = time.time()
+
+        inspect = Mock()
+        inspect.active.return_value = {
+            "some_worker": [{"name": "a_task", "delivery_info": {"routing_key": "foo"}}]
+        }
+
+        monkeypatch.setattr(celery.control, "inspect", lambda: inspect)
+        celery.connection_for_read().channel().client.scan_iter.return_value = [
+            b"foo",
+        ]
+        celery.connection_for_read().channel().client.lindex.return_value = bytes(
+            json.dumps({"properties": {"published_at": now - 60}}), "utf-8"
+        )
+        celery.connection_for_read().channel().client.llen.return_value = 1
+
+        worker_1["CELERY"] = {"TRACK_BUSY_JOBS": True}
+        collector = CeleryMetricsCollector(worker_1, celery)
+        metrics = collector.collect()
+
+        assert len(metrics) == 2
+
+        assert metrics[0].measurement == "busy"
+        assert metrics[0].queue_name == "foo"
+        assert metrics[0].value == 1
+
+        assert metrics[1].measurement == "queue_time"
+        assert metrics[1].queue_name == "foo"
+        assert metrics[1].value == approx(60000, abs=100)
 
 
 class TestRQMetricsCollector:


### PR DESCRIPTION
This PR adds support for tracking busy jobs with RQ and Celery.

As has been the case with other features, Celery takes a bit more effort than RQ to make things work, and there are caveats. In this case, if `TRACK_BUSY_JOBS` is turned on, the Celery integration will report busy jobs counts only when workers are processing jobs. If there is no work, `self.inspect.active()` will return `None` and no busy metrics will be reported.

If this is a blocker and busy counts should be reported even if there is no work, I can take another look and find a workaround.