### PR TITLE
fix: Fix pulling incorrect configuration values for Celery

### DIFF
--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -47,7 +47,7 @@ class CeleryMetricsCollector(JobMetricsCollector):
     def __init__(self, config: Config, broker: Celery):
         super().__init__(config=config)
 
-        self.config["CELERY"] = {**DEFAULTS, **self.config.get("RQ", {})}
+        self.config["CELERY"] = {**DEFAULTS, **self.config.get("CELERY", {})}
 
         self.broker = broker
         connection = self.broker.connection_for_read()

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -94,6 +94,19 @@ class TestJobMetricsCollector:
 
 
 class TestCeleryMetricsCollector:
+    def test_adapter_config(self, render_worker, celery):
+        celery.connection_for_read().channel().client.scan_iter.return_value = []
+        render_worker["CELERY"] = {
+            "ENABLED": False,
+            "QUEUES": ["foo", "bar"],
+        }
+        collector = CeleryMetricsCollector(render_worker, celery)
+        assert collector.adapter_config == {
+            "ENABLED": False,
+            "QUEUES": ["foo", "bar"],
+            "MAX_QUEUES": 20,
+        }
+
     def test_incorrect_driver(self, worker_1, celery):
         celery.connection_for_read().transport.driver_name = "not_redis"
         with raises(NotImplementedError):


### PR DESCRIPTION
This PR fixes fetching Celery configuration options incorrectly due to a botched copy-paste.