### PR TITLE
chore: Migrate from setuptools to importlib

### DIFF
--- a/judoscale/celery/__init__.py
+++ b/judoscale/celery/__init__.py
@@ -1,8 +1,8 @@
 import time
+from importlib import metadata
 from typing import Mapping
 
 from celery import Celery
-from celery import __version__ as celery_version
 from celery.signals import before_task_publish
 
 from judoscale.celery.collector import CeleryMetricsCollector
@@ -23,7 +23,7 @@ def judoscale_celery(celery: Celery, extra_config: Mapping = {}) -> None:
     collector = CeleryMetricsCollector(config=judoconfig, broker=celery)
     adapter = Adapter(
         identifier="judoscale-celery",
-        adapter_info=AdapterInfo(platform_version=celery_version),
+        adapter_info=AdapterInfo(platform_version=metadata.version("celery")),
         metrics_collector=collector,
     )
 

--- a/judoscale/core/adapter.py
+++ b/judoscale/core/adapter.py
@@ -1,11 +1,10 @@
 from dataclasses import asdict, dataclass
+from importlib import metadata
 from typing import Optional
-
-from pkg_resources import get_distribution
 
 from judoscale.core.metrics_collectors import Collector
 
-JUDOSCALE_VERSION = get_distribution("judoscale").version
+JUDOSCALE_VERSION = metadata.version("judoscale")
 
 
 @dataclass

--- a/judoscale/django/middleware.py
+++ b/judoscale/django/middleware.py
@@ -1,4 +1,4 @@
-from django import get_version as django_version
+from importlib import metadata
 
 from judoscale.core.adapter import Adapter, AdapterInfo
 from judoscale.core.config import config as judoconfig
@@ -15,7 +15,7 @@ class RequestQueueTimeMiddleware:
         self.collector = WebMetricsCollector(judoconfig)
         adapter = Adapter(
             identifier="judoscale-django",
-            adapter_info=AdapterInfo(platform_version=django_version()),
+            adapter_info=AdapterInfo(platform_version=metadata.version("django")),
             metrics_collector=self.collector,
         )
         reporter.add_adapter(adapter)

--- a/judoscale/flask/judoscale.py
+++ b/judoscale/flask/judoscale.py
@@ -1,8 +1,7 @@
+from importlib import metadata
 from typing import Optional
 
-from flask import Flask
-from flask import __version__ as flask_version
-from flask import request
+from flask import Flask, request
 
 from judoscale.core.adapter import Adapter, AdapterInfo
 from judoscale.core.config import config as judoconfig
@@ -32,7 +31,7 @@ class Judoscale:
         collector = WebMetricsCollector(judoconfig)
         adapter = Adapter(
             identifier="judoscale-flask",
-            adapter_info=AdapterInfo(platform_version=flask_version),
+            adapter_info=AdapterInfo(platform_version=metadata.version("flask")),
             metrics_collector=collector,
         )
         reporter.add_adapter(adapter)

--- a/judoscale/rq/__init__.py
+++ b/judoscale/rq/__init__.py
@@ -1,6 +1,6 @@
+from importlib import metadata
 from typing import Mapping
 
-import rq
 from redis import Redis
 
 from judoscale.core.adapter import Adapter, AdapterInfo
@@ -14,7 +14,7 @@ def judoscale_rq(redis: Redis, extra_config: Mapping = {}) -> None:
     collector = RQMetricsCollector(config=judoconfig, redis=redis)
     adapter = Adapter(
         identifier="judoscale-rq",
-        adapter_info=AdapterInfo(platform_version=rq.VERSION),
+        adapter_info=AdapterInfo(platform_version=metadata.version("rq")),
         metrics_collector=collector,
     )
 


### PR DESCRIPTION
Using `pkg_resources` (distributed with `setuptools`) has been deprecated in favour of newer and improved modules from `importlib`. https://setuptools.pypa.io/en/latest/pkg_resources.html

This PR:

1. swaps out `pkg_resources.get_distribution` for `importlib.metadata.version`, and
2. starts using `importlib.metadata.version` for getting package version information for supported integrations.