### PR TITLE
fix: Fix crash when accessing missing Celery task properties

### DIFF
--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -108,9 +108,14 @@ class CeleryMetricsCollector(JobMetricsCollector):
         logger.debug(f"Collecting metrics for queues {list(self.queues)}")
         for queue in self.queues:
             if task := self.oldest_task(queue):
-                if published_at := task["properties"].get("published_at"):
+                if published_at := task.get("properties", {}).get("published_at"):
                     metrics.append(
                         Metric.for_queue(queue_name=queue, oldest_job_ts=published_at)
+                    )
+                else:
+                    logger.warning(
+                        "Unable to find `published_at` in task properties for "
+                        f"task ID {task['id']}."
                     )
             else:
                 metrics.append(


### PR DESCRIPTION
This PR fixes accessing task properties for tasks that do not have properties. This could happen when an older version of Celery is used or if there are tasks that were enqueued before the Judoscale Celery integration was introduced to the codebase.