### PR TITLE
Prevent reporter from running if Config.is_enabled is False

### DIFF
--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -48,6 +48,10 @@ class Reporter:
             self.collectors.append(adapter.metrics_collector)
 
     def start(self):
+        if not self.config.is_enabled:
+            logger.info("Reporter not started: API_BASE_URL not set")
+            return
+
         logger.info(f"Starting reporter for process {self.pid}")
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -70,3 +70,14 @@ class TestReporter:
         collector_instance_1.add(Metric(measurement="qt", timestamp=0, value=0))
         collector_instance_2.add(Metric(measurement="qt", timestamp=0, value=0))
         assert len(reporter.all_metrics) == 2
+
+    def test_start_without_api_base_url(self, reporter, caplog):
+        assert not reporter.config.is_enabled
+        reporter.start()
+        assert not reporter._running
+
+    def test_start(self, reporter):
+        reporter.config["API_BASE_URL"] = "https://example.com"
+        assert reporter.config.is_enabled
+        reporter.start()
+        assert reporter._running


### PR DESCRIPTION
Although middleware and extension code already checks whether or not they should be starting the reporter, this PR adds a guard into `Reporter.start()` to prevent the reporter from running in scenarios where folks might be running the adapter in a different way.