### PR TITLE
Simplify RuntimeContainer

### DIFF
--- a/judoscale/core/metrics_collectors.py
+++ b/judoscale/core/metrics_collectors.py
@@ -21,17 +21,13 @@ class MetricsCollector:
 
     @property
     def should_collect(self) -> bool:
-        return True
+        return self.config.is_enabled
 
 
 class WebMetricsCollector(MetricsCollector):
     def __init__(self, config: Config):
         self.store = MetricsStore()
         super().__init__(config=config)
-
-    @property
-    def should_collect(self):
-        return self.config["RUNTIME_CONTAINER"].is_web_instance
 
     def add(self, metric: Metric):
         """
@@ -74,7 +70,8 @@ class JobMetricsCollector(MetricsCollector):
     @property
     def should_collect(self):
         return (
-            self.adapter_config["ENABLED"]
+            super().should_collect
+            and self.adapter_config["ENABLED"]
             and not self.config["RUNTIME_CONTAINER"].is_redundant_instance
         )
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,24 +5,28 @@ from judoscale.core.config import Config
 
 @fixture
 def heroku_web_1(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("DYNO", "web.1")
     return Config.initialize()
 
 
 @fixture
 def heroku_web_2(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("DYNO", "web.2")
     return Config.initialize()
 
 
 @fixture
 def heroku_worker_1(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("DYNO", "worker.1")
     return Config.initialize()
 
 
 @fixture
 def heroku_worker_2(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("DYNO", "worker.2")
     return Config.initialize()
 
@@ -31,7 +35,6 @@ def heroku_worker_2(monkeypatch):
 def render_web(monkeypatch):
     monkeypatch.setenv("RENDER_SERVICE_ID", "srv-123")
     monkeypatch.setenv("RENDER_INSTANCE_ID", "srv-123-abc-def")
-    monkeypatch.setenv("RENDER_SERVICE_TYPE", "web")
     return Config.initialize()
 
 
@@ -39,7 +42,6 @@ def render_web(monkeypatch):
 def render_worker(monkeypatch):
     monkeypatch.setenv("RENDER_SERVICE_ID", "srv-123")
     monkeypatch.setenv("RENDER_INSTANCE_ID", "srv-123-abc-def")
-    monkeypatch.setenv("RENDER_SERVICE_TYPE", "worker")
     return Config.initialize()
 
 

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -26,11 +26,11 @@ def celery():
 
 
 class TestWebMetricsCollector:
-    def test_should_collect(self, web_all):
+    def test_should_collect_web(self, web_all):
         assert WebMetricsCollector(web_all).should_collect
 
-    def test_should_not_collect(self, worker_all):
-        assert not WebMetricsCollector(worker_all).should_collect
+    def test_should_collect_worker(self, worker_all):
+        assert WebMetricsCollector(worker_all).should_collect
 
     def test_add(self, web_all):
         collector = WebMetricsCollector(web_all)
@@ -53,6 +53,18 @@ class TestJobMetricsCollector:
             match="Implement `adapter_config` in a subclass.",
         ):
             assert JobMetricsCollector(web_1).should_collect
+
+    def test_should_collect_web(self, web_1, monkeypatch):
+        monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"ENABLED": True})
+        assert JobMetricsCollector(web_1).should_collect
+
+    def test_should_collect_worker(self, worker_1, monkeypatch):
+        monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"ENABLED": True})
+        assert JobMetricsCollector(worker_1).should_collect
+
+    def test_should_not_collect_worker_2(self, heroku_worker_2, monkeypatch):
+        monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"ENABLED": True})
+        assert not JobMetricsCollector(heroku_worker_2).should_collect
 
     def test_limit_max_queues_under_limit(self, web_1, monkeypatch):
         monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"MAX_QUEUES": 2})

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,9 +10,7 @@ class TestConfig:
         }
         config = Config.for_heroku(fake_env)
 
-        assert config["RUNTIME_CONTAINER"].service_name == "web"
-        assert config["RUNTIME_CONTAINER"].instance == "1"
-        assert config["RUNTIME_CONTAINER"].service_type == "web"
+        assert config["RUNTIME_CONTAINER"] == "web.1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://api.example.com"
 
@@ -25,9 +23,7 @@ class TestConfig:
         }
         config = Config.for_render(fake_env)
 
-        assert config["RUNTIME_CONTAINER"].service_name == "srv-123"
-        assert config["RUNTIME_CONTAINER"].instance == "abc-456"
-        assert config["RUNTIME_CONTAINER"].service_type == "web"
+        assert config["RUNTIME_CONTAINER"] == "abc-456"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/srv-123"
 
@@ -69,9 +65,7 @@ class TestConfig:
         }
         config = Config.for_heroku(fake_env)
         assert config["API_BASE_URL"] == "https://api.example.com"
-        assert config["RUNTIME_CONTAINER"].service_name == "worker"
-        assert config["RUNTIME_CONTAINER"].instance == "1"
-        assert config["RUNTIME_CONTAINER"].service_type == "other"
+        assert config["RUNTIME_CONTAINER"] == "worker.1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["REPORT_INTERVAL_SECONDS"] == 10
 
@@ -110,22 +104,14 @@ class TestConfig:
 
 
 class TestRuntimeContainer:
-    def test_is_web_instance(self):
-        container = RuntimeContainer("web", "1", "web")
-        assert container.is_web_instance
-
-    def test_is_not_web_instance(self):
-        container = RuntimeContainer("worker", "1", "other")
-        assert not container.is_web_instance
-
     def test_is_redundant_instance(self):
-        container = RuntimeContainer("web", "2", "web")
+        container = RuntimeContainer("web.2")
         assert container.is_redundant_instance
 
     def test_is_not_redundant_instance(self):
-        container = RuntimeContainer("web", "1", "web")
+        container = RuntimeContainer("web.1")
         assert not container.is_redundant_instance
 
     def test_string_representation(self):
-        container = RuntimeContainer("web", "1", "web")
+        container = RuntimeContainer("web.1")
         assert str(container) == "web.1"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -72,12 +72,12 @@ class TestReporter:
         assert len(reporter.all_metrics) == 2
 
     def test_start_without_api_base_url(self, reporter, caplog):
+        reporter.config["API_BASE_URL"] = None
         assert not reporter.config.is_enabled
         reporter.start()
         assert not reporter._running
 
     def test_start(self, reporter):
-        reporter.config["API_BASE_URL"] = "https://example.com"
         assert reporter.config.is_enabled
         reporter.start()
         assert reporter._running


### PR DESCRIPTION
Simplify `RuntimeContainer` as in judoscale/judoscale-ruby#178. Additionally, tighten up `.should_collect`.