### PR TITLE
Allow setting Judoscale log level using an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,24 @@ JUDOSCALE = {
 
 > :warning: **NOTE:** Django-RQ enables configuring RQ such that different queues and workers use _different_ Redis instances. Judoscale currently only supports connecting to and monitoring queue latency on a single Redis instance.
 
+## Debugging & troubleshooting
+
+If Judoscale is not recognizing your adapter installation or if you're not seeing expected metrics in Judoscale, you'll want to check the logging output. Here's how you'd do that on Heroku.
+
+First, enable debug logging:
+
+```sh
+heroku config:set JUDOSCALE_LOG_LEVEL=debug
+```
+
+Then, tail your logs while your app initializes:
+
+```sh
+heroku logs --tail | grep Judoscale
+```
+
+You should see Judoscale collecting and reporting metrics every 10 seconds from every running process. If the issue is not clear from the logs, email help@judoscale.com for support. Please include any logging you've collected and any other behavior you've observed.
+
 ## Development
 
 This repo includes a `sample-apps` directory containing apps you can run locally. These apps use the `judoscale` adapter, but they override `API_BASE_URL` so they're not connected to the real Judoscale API. Instead, they post API requests to https://requestinspector.com so you can observe the API behavior.

--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -25,9 +25,13 @@ class Config(UserDict):
             API_BASE_URL=api_base_url,
         )
 
-        for key in {"LOG_LEVEL", "RQ", "CELERY"}:
+        for key in {"RQ", "CELERY"}:
             if key in env:
                 initialdata[key] = env[key]
+
+        initialdata["LOG_LEVEL"] = env.get(
+            "JUDOSCALE_LOG_LEVEL", env.get("LOG_LEVEL", initialdata["LOG_LEVEL"])
+        )
 
         super().__init__(initialdata)
         self._prepare_logging()

--- a/sample-apps/django_sample/bin/heroku
+++ b/sample-apps/django_sample/bin/heroku
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-heroku local --procfile Procfile.heroku
+JUDOSCALE_LOG_LEVEL=debug heroku local --procfile Procfile.heroku

--- a/sample-apps/django_sample/bin/render
+++ b/sample-apps/django_sample/bin/render
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-heroku local --procfile Procfile.render
+JUDOSCALE_LOG_LEVEL=debug heroku local --procfile Procfile.render

--- a/sample-apps/django_sample/django_sample/settings.py
+++ b/sample-apps/django_sample/django_sample/settings.py
@@ -46,7 +46,7 @@ JUDOSCALE = {
     # This sample app is intended to be run locally, so Judoscale API requests are
     # sent to a mock endpoint.
     "API_BASE_URL": "https://requestinspector.com/inspect/judoscale-django",
-    "LOG_LEVEL": "DEBUG",
+    # "LOG_LEVEL": "DEBUG",
     "REPORT_INTERVAL_SECONDS": 15,
 }
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -41,6 +41,19 @@ class TestConfig:
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/srv-123"
 
+    def test_judoscale_log_level_env(self):
+        fake_env = {
+            "DYNO": "web.1",
+            "LOG_LEVEL": "INFO",
+            "JUDOSCALE_LOG_LEVEL": "WARN",
+            "JUDOSCALE_URL": "https://api.example.com",
+        }
+        config = Config.for_heroku(fake_env)
+
+        assert config["RUNTIME_CONTAINER"] == "web.1"
+        assert config["LOG_LEVEL"] == "WARN"
+        assert config["API_BASE_URL"] == "https://api.example.com"
+
     def test_is_enabled(self):
         config = Config(None, "", {})
         assert not config.is_enabled


### PR DESCRIPTION
You can now set Judoscale's log level without a code change using the `JUDOSCALE_LOG_LEVEL` env var. This is useful when troubleshooting your Judoscale adapter behavior.