### PR TITLE
fix: Redis client configuration for RQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -385,7 +385,8 @@ Accepted formats are:
 JUDOSCALE = {
     # Configuring with a Redis server URL
     "REDIS": {
-        "URL": os.getenv("REDISTOGO_URL")
+        "URL": os.getenv("REDISTOGO_URL"),
+        "SSL_CERT_REQS": None  # If you are running on Heroku and using Heroku Data for Redis Premium
     }
 
     # Configuring as kwargs to Redis(...)
@@ -393,9 +394,12 @@ JUDOSCALE = {
         "HOST": "localhost",
         "PORT": 6379,
         "DB": 0
+        "SSL_CERT_REQS": None  # If you are running on Heroku and using Heroku Data for Redis Premium
     }
 }
 ```
+
+> :warning: **NOTE:** If you are running on Heroku and using any of the Premium plans for Heroku Data for Redis, you will have to turn off SSL certificate verification as per https://help.heroku.com/HC0F8CUS/redis-connection-issues.
 
 If you are using [Django-RQ](https://github.com/rq/django-rq/tree/master), you can also pull configuration from `RQ_QUEUES` directly:
 

--- a/judoscale/django/redis.py
+++ b/judoscale/django/redis.py
@@ -1,0 +1,24 @@
+import os
+
+from redis import Redis
+
+
+class RedisHelper:
+    def redis_connection(self, redis_config: dict = None) -> Redis:
+        """
+        Return a Redis connection from an RQ queue configuration
+        """
+        if redis_config is not None:
+            config = {k.lower(): v for k, v in redis_config.items()}
+            if redis_url := config.get("url"):
+                del config["url"]
+                return Redis.from_url(redis_url, **config)
+            else:
+                return Redis(**config)
+        elif redis_url := os.getenv("REDIS_URL"):
+            return Redis.from_url(redis_url)
+        else:
+            raise RuntimeError(
+                "Missing Redis connection configuration. Please set either "
+                "settings.JUDOSCALE['REDIS'] or REDIS_URL environment variable."
+            )

--- a/judoscale/rq/apps.py
+++ b/judoscale/rq/apps.py
@@ -35,7 +35,8 @@ class JudoscaleRQConfig(AppConfig):
         if redis_config := settings.JUDOSCALE.get("REDIS"):
             config = {k.lower(): v for k, v in redis_config.items()}
             if redis_url := config.get("url"):
-                return Redis.from_url(redis_url)
+                del config["url"]
+                return Redis.from_url(redis_url, **config)
             else:
                 return Redis(**config)
         elif redis_url := os.getenv("REDIS_URL"):

--- a/judoscale/rq/apps.py
+++ b/judoscale/rq/apps.py
@@ -1,18 +1,17 @@
 import logging
-import os
 
 from django.apps import AppConfig
 from django.conf import settings
-from redis import Redis
 
 from judoscale.core.config import config as judoconfig
 from judoscale.core.reporter import reporter
+from judoscale.django.redis import RedisHelper
 from judoscale.rq import judoscale_rq
 
 logger = logging.getLogger(__name__)
 
 
-class JudoscaleRQConfig(AppConfig):
+class JudoscaleRQConfig(AppConfig, RedisHelper):
     name = "judoscale.rq"
     label = "judoscale_rq"
     verbose_name = "Judoscale (RQ)"
@@ -24,25 +23,5 @@ class JudoscaleRQConfig(AppConfig):
             logger.info("Not activated - No API URL provided")
             return
 
-        judoscale_rq(self.redis_connection)
+        judoscale_rq(self.redis_connection(settings.JUDOSCALE.get("REDIS")))
         reporter.ensure_running()
-
-    @property
-    def redis_connection(self):
-        """
-        Return a Redis connection from an RQ queue configuration
-        """
-        if redis_config := settings.JUDOSCALE.get("REDIS"):
-            config = {k.lower(): v for k, v in redis_config.items()}
-            if redis_url := config.get("url"):
-                del config["url"]
-                return Redis.from_url(redis_url, **config)
-            else:
-                return Redis(**config)
-        elif redis_url := os.getenv("REDIS_URL"):
-            return Redis.from_url(redis_url)
-        else:
-            raise RuntimeError(
-                "Missing Redis connection configuration. Please set either "
-                "settings.JUDOSCALE['REDIS'] or REDIS_URL environment variable."
-            )


### PR DESCRIPTION
Heroku Data for Redis premium plans only offer a TLS connection to Redis, which uses self-signed certificates, which require you to configure the verify_mode SSL setting of your Redis client.

This PR fixes the inability to configure this in `JUDOSCALE["REDIS"]` configuration.