### PR TITLE
feat: Expand Django version range to cover 5.x.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ packages = [{include = "judoscale"}]
 [tool.poetry.dependencies]
 python = "^3.8"
 requests = "<3.0.0"
-django = { version = ">=2.1.0,<5.0.0", optional = true }
+django = { version = ">=2.1.0,<6.0.0", optional = true }
 flask = { version = ">=1.1.0,<3.0.0", optional = true }
 celery = { version = ">=4.4.0,<6.0.0", extras = ["redis"], optional = true }
 rq = { version = ">=1.0.0,<2.0.0", optional = true }


### PR DESCRIPTION
I had a look through the changelog and upgrade notes for Django 5.0 and I don't think there is anything in there that prevents Judoscale from supporting Django 5.x.