### PR TITLE
Log Celery queue name when published_at isn't found in task properties

### DIFF
--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -74,7 +74,7 @@ class CeleryMetricsCollector(JobMetricsCollector):
 
         system_queues = {"unacked", "unacked_index"}
         user_queues = {
-            q.decode("utf-8") if type(q) is bytes else q
+            q.decode("utf-8") if isinstance(q, bytes) else q
             for q in self.redis.scan_iter(match="[^_]*", _type="list")
         }
         logger.debug(f"Found initial queues: {list(user_queues)}")

--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -132,7 +132,7 @@ class CeleryMetricsCollector(JobMetricsCollector):
                     task_id = task.get("id", None)
                     logger.warning(
                         "Unable to find `published_at` in task properties for "
-                        f"task ID {task_id}."
+                        f"task ID {task_id} in queue {queue}."
                     )
             else:
                 metrics.append(


### PR DESCRIPTION
At the moment, we'r logging the relatively unhelpful warning `WARNING - [judoscale] Unable to find published_at in task properties for task ID None.`, which isn't very useful for debugging.

This PR adds the queue name from which the task in question was pulled from.