### PR TITLE
fix: Improve automatic queue detection for Celery

### DIFF
--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -144,6 +144,17 @@ class TestCeleryMetricsCollector:
         collector = CeleryMetricsCollector(heroku_worker_1, celery)
         assert collector.queues == set()
 
+    def test_removing_various_celery_queues(self, heroku_worker_1, celery):
+        celery.connection_for_read().channel().client.scan_iter.return_value = [
+            b"unacked",
+            b"unacked_index",
+            b"_kombu.binding.celeryev",
+            b"e752fa70-f772-3c04-b05d-79b2a79ce766.reply.celery.pidbox",
+            b"user_queue",
+        ]
+        collector = CeleryMetricsCollector(heroku_worker_1, celery)
+        assert collector.queues == {"user_queue"}
+
     def test_collect_empty_queue(self, worker_1, celery):
         celery.connection_for_read().channel().client.scan_iter.return_value = [b"foo"]
         celery.connection_for_read().channel().client.lindex.return_value = None


### PR DESCRIPTION
In certain configurations the adapter library outputs a large volume of warning logs that look something like this:

> WARNING - [judoscale] Unable to find `published_at` in task properties for task ID None in queue e752fa70-f772-3c04-b05d-79b2a79ce766.reply.celery.pidbox.

This happens because `e752fa70-f772-3c04-b05d-79b2a79ce766.reply.celery.pidbox` is incorrectly detected as a user queue. Consequently, the adapter tries to inspect the queue to determine queue latency, but the items in there do not correspond to Celery tasks, which causes the warning log lines to get emitted by the adapter library.

This PR tightens up the mechanism by which the adapter tries to discover the Celery queues to monitor.