### PR TITLE
chore: Add docker-compose.yml for sample apps

### DIFF
--- a/sample-apps/docker-compose.yml
+++ b/sample-apps/docker-compose.yml
@@ -1,0 +1,6 @@
+name: "judoscale-sample-apps"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"


### PR DESCRIPTION
Make it possible to run the dependency(ies) for the sample apps in an isolated environment — Docker.