### PR TITLE
fix: Bump Flask extra to <4.0.0

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -858,4 +858,4 @@ rq = ["rq"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "4634696a289c1f2254573b9b060c00f0dcaec5ace3c84395b0440995e7f6fea9"
+content-hash = "79aff140ed052f5f236e62611fb3c96347be6aeb5b1d2b10e8af5e0e284110e6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ packages = [{ include = "judoscale" }]
 python = "^3.8"
 requests = "<3.0.0"
 django = { version = ">=2.1.0,<6.0.0", optional = true }
-flask = { version = ">=1.1.0,<3.0.0", optional = true }
+flask = { version = ">=1.1.0,<4.0.0", optional = true }
 celery = { version = ">=4.4.0,<6.0.0", extras = ["redis"], optional = true }
 rq = { version = ">=1.0.0,<2.0.0", optional = true }
 


### PR DESCRIPTION
Flask 3 was released a while back but our `pyproject.toml` still specifies `<3.0.0` which prevents folks from using Flask 3+ with Judoscale. This PR bumps the Flask extra to `<4.0.0`.