### PR TITLE
Fix broken docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ An example configuration dictionary accepted by `extra_config`:
         # Enable or disable (default) tracking how many jobs are currently being
         # processed in each queue.
         # This allows Judoscale to avoid downscaling workers that are executing jobs.
-        # See documentation: https://judoscale.com/docs/long-running-jobs-ruby#enable-long-running-job-support-in-the-dashboard
+        # See documentation: https://judoscale.com/docs/long-running-jobs
         # NOTE: This option requires workers to have unique names. If you are running
         # multiple Celery workers on the same machine, make sure to give each
         # worker a distinct name.
@@ -320,7 +320,7 @@ An example configuration dictionary accepted by `extra_config`:
         # Enable or disable (default) tracking how many jobs are currently being
         # processed in each queue.
         # This allows Judoscale to avoid downscaling workers that are executing jobs.
-        # See documentation: https://judoscale.com/docs/long-running-jobs-ruby#enable-long-running-job-support-in-the-dashboard
+        # See documentation: https://judoscale.com/docs/long-running-jobs
         "TRACK_BUSY_JOBS": False,
 }
 ```


### PR DESCRIPTION
The URL with [`-ruby`](https://judoscale.com/docs/long-running-jobs-ruby#enable-long-running-job-support-in-the-dashboard) has gone the way of the Norwegian blue parrot.