### PR TITLE
Configure runtime container for Railway

### DIFF
--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -67,7 +67,7 @@ class Config(UserDict):
         service_id = env.get("RENDER_SERVICE_ID")
         instance = env.get("RENDER_INSTANCE_ID").replace(f"{service_id}-", "")
         runtime_container = RuntimeContainer(instance)
-        api_base_url = f"https://adapter.judoscale.com/api/{service_id}"
+        api_base_url = env.get("JUDOSCALE_URL") or f"https://adapter.judoscale.com/api/{service_id}"
         return cls(runtime_container, api_base_url, env)
 
     @classmethod

--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -51,6 +51,8 @@ class Config(UserDict):
             return cls.for_render(env)
         elif env.get("ECS_CONTAINER_METADATA_URI"):
             return cls.for_ecs(env)
+        elif env.get("RAILWAY_REPLICA_ID"):
+            return cls.for_railway(env)
         else:
             return cls(None, "", env)
 
@@ -72,6 +74,12 @@ class Config(UserDict):
     def for_ecs(cls, env: Mapping):
         instance = env["ECS_CONTAINER_METADATA_URI"].split("/")[-1]
         runtime_container = RuntimeContainer(instance)
+        api_base_url = env.get("JUDOSCALE_URL")
+        return cls(runtime_container, api_base_url, env)
+
+    @classmethod
+    def for_railway(cls, env: Mapping):
+        runtime_container = RuntimeContainer(env["RAILWAY_REPLICA_ID"])
         api_base_url = env.get("JUDOSCALE_URL")
         return cls(runtime_container, api_base_url, env)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,15 +9,29 @@ class TestConfig:
         fake_env = {
             "DYNO": "web.1",
             "LOG_LEVEL": "WARN",
-            "JUDOSCALE_URL": "https://api.example.com",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
         }
         config = Config.for_heroku(fake_env)
 
         assert config["RUNTIME_CONTAINER"] == "web.1"
         assert config["LOG_LEVEL"] == "WARN"
-        assert config["API_BASE_URL"] == "https://api.example.com"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
     def test_on_render(self):
+        fake_env = {
+            "RENDER_SERVICE_ID": "srv-123",
+            "RENDER_INSTANCE_ID": "srv-123-abc-456",
+            "RENDER_SERVICE_TYPE": "web",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
+            "LOG_LEVEL": "WARN",
+        }
+        config = Config.for_render(fake_env)
+
+        assert config["RUNTIME_CONTAINER"] == "abc-456"
+        assert config["LOG_LEVEL"] == "WARN"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
+
+    def test_on_render_legacy(self):
         fake_env = {
             "RENDER_SERVICE_ID": "srv-123",
             "RENDER_INSTANCE_ID": "srv-123-abc-456",
@@ -33,7 +47,7 @@ class TestConfig:
     def test_on_ecs(self):
         fake_env = {
             "ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/a8880ee042bc4db3ba878dce65b769b6-2750272591",  # noqa
-            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/srv-123",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
             "LOG_LEVEL": "WARN",
         }
         config = Config.for_ecs(fake_env)
@@ -42,7 +56,7 @@ class TestConfig:
             config["RUNTIME_CONTAINER"] == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
         )
         assert config["LOG_LEVEL"] == "WARN"
-        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/srv-123"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
     def test_on_railway(self):
         fake_env = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -11,7 +11,7 @@ class TestConfig:
             "LOG_LEVEL": "WARN",
             "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
         }
-        config = Config.for_heroku(fake_env)
+        config = Config.initialize(fake_env)
 
         assert config["RUNTIME_CONTAINER"] == "web.1"
         assert config["LOG_LEVEL"] == "WARN"
@@ -25,7 +25,7 @@ class TestConfig:
             "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
             "LOG_LEVEL": "WARN",
         }
-        config = Config.for_render(fake_env)
+        config = Config.initialize(fake_env)
 
         assert config["RUNTIME_CONTAINER"] == "abc-456"
         assert config["LOG_LEVEL"] == "WARN"
@@ -38,7 +38,7 @@ class TestConfig:
             "RENDER_SERVICE_TYPE": "web",
             "LOG_LEVEL": "WARN",
         }
-        config = Config.for_render(fake_env)
+        config = Config.initialize(fake_env)
 
         assert config["RUNTIME_CONTAINER"] == "abc-456"
         assert config["LOG_LEVEL"] == "WARN"
@@ -50,7 +50,7 @@ class TestConfig:
             "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
             "LOG_LEVEL": "WARN",
         }
-        config = Config.for_ecs(fake_env)
+        config = Config.initialize(fake_env)
 
         assert (
             config["RUNTIME_CONTAINER"] == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
@@ -65,7 +65,7 @@ class TestConfig:
             "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
             "LOG_LEVEL": "WARN",
         }
-        config = Config.for_railway(fake_env)
+        config = Config.initialize(fake_env)
 
         assert (
             config["RUNTIME_CONTAINER"] == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,21 @@ class TestConfig:
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/srv-123"
 
+    def test_on_railway(self):
+        fake_env = {
+            "RAILWAY_SERVICE_ID": "1431de82-74ad-4f1a-b8f2-1952262d66cf",
+            "RAILWAY_REPLICA_ID": "f9c88b6e-0e96-46f2-9884-ece3bf53d009",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
+            "LOG_LEVEL": "WARN",
+        }
+        config = Config.for_railway(fake_env)
+
+        assert (
+            config["RUNTIME_CONTAINER"] == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
+        )
+        assert config["LOG_LEVEL"] == "WARN"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
+
     def test_judoscale_log_level_env(self):
         fake_env = {
             "DYNO": "web.1",


### PR DESCRIPTION
We're early-testing Railway as a platform integration, this adds detection for the Railway environment to report the runtime container as the Railway Replica ID.

It also changes the Render configuration to favor JUDOSCALE_URL, as we are now requiring that to be set for new apps/services, deprecating the service ID api-based URL. (which is still supported by current apps and our backend)

Related:

- https://github.com/judoscale/judoscale-ruby/pull/230
- https://github.com/judoscale/judoscale-node/pull/54