### PR TITLE
Configure runtime container for Fly.io

### DIFF
--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -51,6 +51,8 @@ class Config(UserDict):
             return cls.for_render(env)
         elif env.get("ECS_CONTAINER_METADATA_URI"):
             return cls.for_ecs(env)
+        elif env.get("FLY_MACHINE_ID"):
+            return cls.for_fly(env)
         elif env.get("RAILWAY_REPLICA_ID"):
             return cls.for_railway(env)
         else:
@@ -74,6 +76,12 @@ class Config(UserDict):
     def for_ecs(cls, env: Mapping):
         instance = env["ECS_CONTAINER_METADATA_URI"].split("/")[-1]
         runtime_container = RuntimeContainer(instance)
+        api_base_url = env.get("JUDOSCALE_URL")
+        return cls(runtime_container, api_base_url, env)
+
+    @classmethod
+    def for_fly(cls, env: Mapping):
+        runtime_container = RuntimeContainer(env["FLY_MACHINE_ID"])
         api_base_url = env.get("JUDOSCALE_URL")
         return cls(runtime_container, api_base_url, env)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,9 +52,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert (
-            config["RUNTIME_CONTAINER"] == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
-        )
+        assert config["RUNTIME_CONTAINER"] == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -67,9 +65,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert (
-            config["RUNTIME_CONTAINER"] == "683d924b322418"
-        )
+        assert config["RUNTIME_CONTAINER"] == "683d924b322418"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -82,9 +78,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert (
-            config["RUNTIME_CONTAINER"] == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
-        )
+        assert config["RUNTIME_CONTAINER"] == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -58,6 +58,21 @@ class TestConfig:
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
+    def test_on_fly(self):
+        fake_env = {
+            "FLY_MACHINE_ID": "683d924b322418",
+            "FLY_PROCESS_GROUP": "web",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
+            "LOG_LEVEL": "WARN",
+        }
+        config = Config.initialize(fake_env)
+
+        assert (
+            config["RUNTIME_CONTAINER"] == "683d924b322418"
+        )
+        assert config["LOG_LEVEL"] == "WARN"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
+
     def test_on_railway(self):
         fake_env = {
             "RAILWAY_SERVICE_ID": "1431de82-74ad-4f1a-b8f2-1952262d66cf",


### PR DESCRIPTION
Adds detection for the Fly environment to report the runtime container as the Fly Machine ID.

(The Fly.io integration is currently in early-testing)

<details><summary>Sample ENV vars</summary>
<p>

![Screenshot 2025-02-17 at 11 25 42](https://github.com/user-attachments/assets/adb13219-49f8-410e-a02d-af6fb87df638)

</p>
</details> 
