### PR TITLE
Report queue time metric with the expected `qt` identifier

### DIFF
--- a/judoscale/core/metric.py
+++ b/judoscale/core/metric.py
@@ -33,7 +33,7 @@ class Metric:
     timestamp: float  # Unix timestamp in fractional seconds
     value: int
     queue_name: Optional[str] = None
-    measurement: str = "queue_time"
+    measurement: str = "qt"
 
     @property
     def as_tuple(self) -> Tuple[int, int, str, Optional[str]]:

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -246,7 +246,7 @@ class TestCeleryMetricsCollector:
         assert metrics[0].queue_name == "foo"
         assert metrics[0].value == 1
 
-        assert metrics[1].measurement == "queue_time"
+        assert metrics[1].measurement == "qt"
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)
 
@@ -293,11 +293,11 @@ class TestCeleryMetricsCollector:
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == 1
 
-        assert metrics[2].measurement == "queue_time"
+        assert metrics[2].measurement == "qt"
         assert metrics[2].queue_name == "bar"
         assert metrics[2].value == 0
 
-        assert metrics[3].measurement == "queue_time"
+        assert metrics[3].measurement == "qt"
         assert metrics[3].queue_name == "foo"
         assert metrics[3].value == approx(60000, abs=100)
 
@@ -401,6 +401,6 @@ class TestRQMetricsCollector:
         assert metrics[0].queue_name == "foo"
         assert metrics[0].value == 1
 
-        assert metrics[1].measurement == "queue_time"
+        assert metrics[1].measurement == "qt"
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)


### PR DESCRIPTION
Our backend expects the metric identifiers to be reported from all our libraries as "short" versions, but we were sending `queue_time` instead here, which the backend is translating correctly but shouldn't have to.

The backend will continue to have legacy support for `queue_time` for a while for current adapters out there, but this changes the Python adapter going forward  to report metrics using `qt` to match our other adapters.

https://github.com/judoscale/judoscale-ruby/blob/ad739e4cf41e44a8e79c502afc02ffa461c5f8e1/judoscale-ruby/lib/judoscale/request_middleware.rb#L31
https://github.com/judoscale/judoscale-node/blob/408fe1db8e153b9f0d83cab3435b22d2e3a23e70/packages/express/src/index.js#L15 
https://github.com/judoscale/judoscale-node/blob/408fe1db8e153b9f0d83cab3435b22d2e3a23e70/packages/fastify/src/plugin.js#L13