### PR TITLE
fix: Ensure reporter thread only starts once per process

### DIFF
--- a/judoscale/core/__init__.py
+++ b/judoscale/core/__init__.py
@@ -1,0 +1,21 @@
+import signal
+import sys
+
+from judoscale.core.reporter import reporter
+
+previous_handler = signal.getsignal(signal.SIGTERM)
+
+def graceful_shutdown(signum, frame):
+    reporter.stop()
+    # If there was a previous handler and it's not SIG_DFL or SIG_IGN, call it
+    if callable(previous_handler) and previous_handler not in (
+        signal.SIG_DFL,
+        signal.SIG_IGN,
+    ):
+        previous_handler(signum, frame)
+    else:
+        # If no previous handler, use default behavior (exit the process)
+        sys.exit(0)
+
+
+signal.signal(signal.SIGTERM, graceful_shutdown)

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -1,6 +1,4 @@
 import os
-import signal
-import sys
 import threading
 import time
 from platform import python_version
@@ -141,21 +139,3 @@ class Reporter:
 
 
 reporter = Reporter(config=config)
-
-previous_handler = signal.getsignal(signal.SIGTERM)
-
-
-def graceful_shutdown(signum, frame):
-    reporter.stop()
-    # If there was a previous handler and it's not SIG_DFL or SIG_IGN, call it
-    if callable(previous_handler) and previous_handler not in (
-        signal.SIG_DFL,
-        signal.SIG_IGN,
-    ):
-        previous_handler(signum, frame)
-    else:
-        # If no previous handler, use default behavior (exit the process)
-        sys.exit(0)
-
-
-signal.signal(signal.SIGTERM, graceful_shutdown)

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -23,6 +23,7 @@ class Reporter:
         self.config = config
         self._thread = None
         self._running = False
+        self._lock = threading.Lock()
         self._stopevent = threading.Event()
         self.collectors: List[Collector] = []
         self.adapters: List[Adapter] = []
@@ -65,8 +66,9 @@ class Reporter:
 
     def ensure_running(self):
         try:
-            if not self.is_running:
-                return self.start()
+            with self._lock:
+                if not self.is_running:
+                    return self.start()
         except Exception as e:
             logger.warning(f"{e.args} - No reporter has initiated")
             pass

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -62,7 +62,6 @@ class Reporter:
         logger.info(f"Starting reporter for process {self.pid}")
         self._thread = threading.Thread(target=self._run_loop, daemon=True)
         self._thread.start()
-        self._running = True
 
     def ensure_running(self):
         try:
@@ -78,11 +77,7 @@ class Reporter:
 
     @property
     def is_running(self):
-        if self._thread and self._thread.is_alive():
-            self._running = True
-        else:
-            self._running = False
-        return self._running
+        return self._thread and self._thread.is_alive()
 
     @property
     def pid(self) -> int:

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -74,9 +74,12 @@ class Reporter:
             logger.warning(f"{e.args} - No reporter has initiated")
             pass
 
-    def signal_handler(self, signum, frame):
+    def stop(self):
         self._stopevent.set()
         self._running = False
+
+    def signal_handler(self, signum, frame):
+        self.stop()
 
     @property
     def is_running(self):

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -78,9 +78,6 @@ class Reporter:
         self._stopevent.set()
         self._running = False
 
-    def signal_handler(self, signum, frame):
-        self.stop()
-
     @property
     def is_running(self):
         if self._thread and self._thread.is_alive():
@@ -149,7 +146,7 @@ previous_handler = signal.getsignal(signal.SIGTERM)
 
 
 def graceful_shutdown(signum, frame):
-    reporter.signal_handler(signum, frame)
+    reporter.stop()
     # If there was a previous handler and it's not SIG_DFL or SIG_IGN, call it
     if callable(previous_handler) and previous_handler not in (
         signal.SIG_DFL,

--- a/sample-apps/django_sample/Procfile.heroku
+++ b/sample-apps/django_sample/Procfile.heroku
@@ -2,4 +2,5 @@
 proxy: npx judoscale-adapter-proxy-server
 
 # Run with --noreload to avoid multiple server processes (and multiple Judoscale reporters)
-web: DYNO=web.1 poetry run gunicorn django_sample.wsgi:application --preload
+# web: DYNO=web.1 poetry run gunicorn django_sample.wsgi:application --preload
+web: DYNO=web.1 poetry run gunicorn django_sample.wsgi:application --preload --workers 3 --threads 2

--- a/sample-apps/django_sample/blog/views.py
+++ b/sample-apps/django_sample/blog/views.py
@@ -1,14 +1,22 @@
 import logging
+import time, random
 
 from django.conf import settings
 from django.http import HttpResponse
 
 logger = logging.getLogger(__name__)
 
-
 def index(request):
     # Log message in level warning as this is Django's default logging level
     logger.warning("Hello, world")
+
+    if sleep_for := request.GET.get("sleep"):
+        try:
+            sleep_for = float(sleep_for)
+        except:
+            sleep_for = random.randint(0, 2)
+        time.sleep(sleep_for)
+
     if url := settings.JUDOSCALE.get("API_BASE_URL"):
         return HttpResponse(
             "Judoscale Django Sample App. "

--- a/sample-apps/django_sample/tests/tests.py
+++ b/sample-apps/django_sample/tests/tests.py
@@ -15,6 +15,7 @@ class TestApp(TestCase):
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests
         reporter.all_metrics
+        reporter.stop()
 
     def test_index_view(self):
         response = self.client.get("/", follow_redirects=True)

--- a/sample-apps/fastapi_sample/Procfile.heroku
+++ b/sample-apps/fastapi_sample/Procfile.heroku
@@ -1,4 +1,6 @@
 # The proxy server adds the X_REQUEST_START header for queue time calculations
 proxy: npx judoscale-adapter-proxy-server
 
-web: DYNO=web.1 poetry run uvicorn app.asgi:app --reload --port 5106
+# Note: --workers & --reload don't work together.
+# web: DYNO=web.1 poetry run uvicorn app.asgi:app --port 5106 --reload
+web: DYNO=web.1 poetry run uvicorn app.asgi:app --port 5106 --workers 3

--- a/sample-apps/fastapi_sample/app/main.py
+++ b/sample-apps/fastapi_sample/app/main.py
@@ -1,3 +1,4 @@
+import time, random
 import app.settings as settings
 from fastapi import FastAPI
 from fastapi.logger import logger
@@ -15,8 +16,16 @@ def create_app() -> FastAPI:
     )
 
     @app.get("/")
-    async def index():
+    async def index(sleep = None):
         logger.warning("Hello, world")
+
+        if sleep:
+            try:
+                sleep_for = float(sleep)
+            except:
+                sleep_for = random.randint(0, 2)
+            time.sleep(sleep_for)
+
         if url := judoconfig.get("API_BASE_URL"):
             return HTMLResponse(
                 "Judoscale FastAPI Sample App. "

--- a/sample-apps/fastapi_sample/tests.py
+++ b/sample-apps/fastapi_sample/tests.py
@@ -18,6 +18,7 @@ class BasicTests(unittest.TestCase):
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests
         reporter.all_metrics
+        reporter.stop()
 
     def test_index_view(self):
         response = self.client.get("/", follow_redirects=True)

--- a/sample-apps/flask_sample/Procfile.heroku
+++ b/sample-apps/flask_sample/Procfile.heroku
@@ -1,5 +1,6 @@
 # The proxy server adds the X_REQUEST_START header for queue time calculations
 proxy: npx judoscale-adapter-proxy-server
 
-web: DYNO=web.1 poetry run gunicorn --preload 'app:create_app()'
+# web: DYNO=web.1 poetry run gunicorn --preload 'app:create_app()'
+web: DYNO=web.1 poetry run gunicorn 'app:create_app()' --preload --workers 3 --threads 2
 #web: flask run -p 5106

--- a/sample-apps/flask_sample/app.py
+++ b/sample-apps/flask_sample/app.py
@@ -1,5 +1,6 @@
+import time, random
 import settings
-from flask import Flask, current_app
+from flask import Flask, current_app, request
 
 from judoscale.flask import Judoscale
 
@@ -15,6 +16,14 @@ def create_app():
     @app.route("/", methods=["GET"])
     def index():
         current_app.logger.warning("Hello, world")
+
+        if sleep_for := request.args.get("sleep"):
+            try:
+                sleep_for = float(sleep_for)
+            except:
+                sleep_for = random.randint(0, 2)
+            time.sleep(sleep_for)
+
         if url := current_app.config["JUDOSCALE"].get("API_BASE_URL"):
             return (
                 "Judoscale Flask Sample App. "

--- a/sample-apps/flask_sample/tests.py
+++ b/sample-apps/flask_sample/tests.py
@@ -19,6 +19,7 @@ class BasicTests(unittest.TestCase):
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests
         reporter.all_metrics
+        reporter.stop()
 
     def test_index_view(self):
         response = self.client.get("/", follow_redirects=True)

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -12,12 +12,16 @@ from judoscale.core.reporter import Reporter
 
 @fixture
 def reporter(heroku_web_1):
-    return Reporter(heroku_web_1)
+    reporter = Reporter(heroku_web_1)
+    yield reporter
+    reporter.stop()
 
 
 @fixture
 def reporter_in_release(heroku_release_1):
-    return Reporter(heroku_release_1)
+    reporter = Reporter(heroku_release_1)
+    yield reporter
+    reporter.stop()
 
 
 class TestReporter:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -85,19 +85,19 @@ class TestReporter:
         reporter.config["API_BASE_URL"] = None
         assert not reporter.config.is_enabled
         reporter.start()
-        assert not reporter._running
+        assert not reporter.is_running
 
     def test_start(self, reporter):
         assert reporter.config.is_enabled
         reporter.start()
-        assert reporter._running
+        assert reporter.is_running
 
     def test_start_in_release(self, reporter_in_release, caplog):
         caplog.set_level(logging.INFO, logger="judoscale")
 
         assert reporter_in_release.config.is_enabled
         reporter_in_release.ensure_running()
-        assert not reporter_in_release._running
+        assert not reporter_in_release.is_running
 
         for record in caplog.records:
             assert record.levelname == "INFO"


### PR DESCRIPTION
### Testing

I tested by running the Django server (here with the Procfile changed to run 3 workers and 2 threads each) with `bin/heroku | grep Starting` to filter just the messages we cared about, and then executed `hey` against the server to hit it with a few concurrent requests: `hey 'http://localhost:5006/?sleep=t' -n 20 -c 5`

Behavior on main:

```
% bin/heroku | grep Starting
1:55:39 PM web.1   |  INFO - [judoscale] Starting reporter for process 11661
1:55:39 PM web.1   |  [2025-08-04 16:55:39 +0000] [11661] [INFO] Starting gunicorn 20.1.0
1:55:42 PM web.1   |  INFO - [judoscale] Starting reporter for process 11664
1:55:42 PM web.1   |  INFO - [judoscale] Starting reporter for process 11666
1:55:42 PM web.1   |  INFO - [judoscale] Starting reporter for process 11666
1:55:42 PM web.1   |  INFO - [judoscale] Starting reporter for process 11665
```

Behavior with fix:

```
% bin/heroku | grep Starting
2:03:53 PM web.1   |  INFO - [judoscale] Starting reporter for process 11906
2:03:53 PM web.1   |  [2025-08-04 17:03:53 +0000] [11906] [INFO] Starting gunicorn 20.1.0
2:03:54 PM web.1   |  INFO - [judoscale] Starting reporter for process 11909
2:03:54 PM web.1   |  INFO - [judoscale] Starting reporter for process 11911
2:03:54 PM web.1   |  INFO - [judoscale] Starting reporter for process 11910
```