### PR TITLE
Test against currently stable Python v3.13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
v3.14 is scheduled to be released early October, but GH actions for python setup is does not seem to have a prerelease setup yet, so let's just wait for it to get released.

https://devguide.python.org/versions/