### PR TITLE
Handle Celery `eta`/`countdown` by skipping future dates and using past dates

### DIFF
--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -258,6 +258,72 @@ class TestCeleryMetricsCollector:
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)
 
+    def test_collect_with_future_eta(self, worker_1, celery):
+        now = time.time()
+        celery.connection_for_read().channel().client.scan_iter.return_value = [
+            b"foo-eta",
+        ]
+        celery.connection_for_read().channel().client.lindex.side_effect = [
+            bytes(
+                json.dumps(
+                    {
+                        "id": "123abc",
+                        "headers": {
+                            "eta": datetime.fromtimestamp(now + 60).isoformat(),
+                        },
+                        "properties": {
+                            "published_at": now - 60,
+                        },
+                    }
+                ),
+                "utf-8",
+            ),
+            bytes(
+                json.dumps({"id": "123abc", "properties": {"published_at": now - 30}}),
+                "utf-8",
+            ),
+        ]
+
+        collector = CeleryMetricsCollector(worker_1, celery)
+        metrics = collector.collect()
+
+        assert len(metrics) == 1
+
+        assert metrics[0].measurement == "qt"
+        assert metrics[0].queue_name == "foo-eta"
+        assert metrics[0].value == approx(30000, abs=100)
+
+    def test_collect_with_past_eta(self, worker_1, celery):
+        now = time.time()
+        celery.connection_for_read().channel().client.scan_iter.return_value = [
+            b"foo-eta",
+        ]
+        celery.connection_for_read().channel().client.lindex.side_effect = [
+            bytes(
+                json.dumps(
+                    {
+                        "id": "123abc",
+                        "headers": {
+                            "eta": datetime.fromtimestamp(now - 30).isoformat(),
+                        },
+                        "properties": {
+                            "published_at": now - 60,
+                        },
+                    }
+                ),
+                "utf-8",
+            )
+        ]
+
+        collector = CeleryMetricsCollector(worker_1, celery)
+        metrics = collector.collect()
+
+        assert len(metrics) == 1
+
+        assert metrics[0].measurement == "qt"
+        assert metrics[0].queue_name == "foo-eta"
+        assert metrics[0].value == approx(30000, abs=100)
+
     def test_collect_with_busy_jobs(self, worker_1, celery, monkeypatch):
         now = time.time()
 


### PR DESCRIPTION
If a task is enqueued with an eta, when looking for the oldest job we
must skip the task if the eta is still in the future, to make sure we
don't use a future-dated task with a potentially older published_at
timestamp to calculate our queue latency.

And if the task has an eta already in the past, we should use that
instead of our published timestamp, to calculate queue time.

This basically ignores the time between the task is published and when
it's actually meant to execute, considering the eta as the "enqueue"
time when available.

This should fix an issue where we sometimes see a spike of queue time
apparently related to the usage of `countdown`/`eta`, because that task
may end up back in the queue and we may pick it up as part of our
reporting, causing us to report a spike in queue time that goes away
within the next report or so. (that is because tasks with `eta` live in
the worker's memory most of the time.)