### PR TITLE
Collect & report task metadata for Celery

### DIFF
--- a/judoscale/core/metric.py
+++ b/judoscale/core/metric.py
@@ -34,6 +34,7 @@ class Metric:
     value: int
     queue_name: Optional[str] = None
     measurement: str = "qt"
+    report_metadata: Optional[dict] = None
 
     @property
     def as_tuple(self) -> Tuple[int, int, str, Optional[str]]:

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -128,6 +128,11 @@ class Reporter:
             "config": self.config.for_report,
             "adapters": dict(adapter.as_tuple for adapter in self.adapters),
             "metrics": [metric.as_tuple for metric in metrics],
+            "metadata": dict(
+                (metric.queue_name, metric.report_metadata)
+                for metric in metrics
+                if metric.report_metadata is not None
+            ),
         }
 
 


### PR DESCRIPTION
This additional task metadata will help troubleshooting an issue with some queue time spikes that we're investigating.

With each queue we'll add information about the task and the timestamps that were used to calculate queue time, so it can hopefully help us identify the source of the queue time spikes.