### PR TITLE
fix: Keep reporter thread alive when a collector raises

### DIFF
--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -89,7 +89,15 @@ class Reporter:
             # Instead, we now wait for the first interval to pass before
             # reporting metrics.
             time.sleep(self.config["REPORT_INTERVAL_SECONDS"])
-            self._report_metrics()
+
+            # Catch absolutely anything so the reporter thread survives
+            # transient/unexpected errors and keeps trying on the next
+            # interval. Without this, a single bad cycle silently
+            # disables all metric reporting until the process restarts.
+            try:
+                self._report_metrics()
+            except Exception as e:
+                logger.exception(f"Reporter cycle failed, will retry: {e}")
 
             if self._stopevent.is_set():
                 break
@@ -100,10 +108,19 @@ class Reporter:
     def all_metrics(self) -> List[Metric]:
         """
         Return a list of all metrics collected by all collectors.
+
+        A failing collector is logged and skipped so that one collector's
+        error doesn't suppress metrics from the others.
         """
         metrics = []
         for collector in self.collectors:
-            metrics.extend(collector.collect())
+            try:
+                metrics.extend(collector.collect())
+            except Exception as e:
+                logger.exception(
+                    f"Collector {type(collector).__name__} failed to "
+                    f"collect metrics, skipping this cycle: {e}"
+                )
         return metrics
 
     TRANSIENT_ERRORS = (

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -132,3 +132,60 @@ class TestReporter:
         reporter._report_metrics()
 
         assert mock_post.call_count == 1
+
+    def test_all_metrics_continues_when_one_collector_raises(
+        self, reporter, caplog
+    ):
+        caplog.set_level(logging.ERROR, logger="judoscale")
+
+        failing_collector = WebMetricsCollector(reporter.config)
+        failing_collector.collect = MagicMock(side_effect=RuntimeError("boom"))
+        reporter.add_adapter(
+            Adapter(
+                identifier="failing",
+                adapter_info=AdapterInfo(runtime_version="0.0.0"),
+                metrics_collector=failing_collector,
+            )
+        )
+
+        healthy_collector = WebMetricsCollector(reporter.config)
+        healthy_collector.add(Metric(measurement="qt", timestamp=0, value=0))
+        reporter.add_adapter(
+            Adapter(
+                identifier="healthy",
+                adapter_info=AdapterInfo(runtime_version="0.0.0"),
+                metrics_collector=healthy_collector,
+            )
+        )
+
+        metrics = reporter.all_metrics
+
+        assert len(metrics) == 1
+        assert any(
+            "failed to collect metrics" in record.message
+            for record in caplog.records
+        )
+
+    @patch.object(time, "sleep")
+    def test_run_loop_survives_report_metrics_exception(
+        self, mock_sleep, reporter, caplog
+    ):
+        caplog.set_level(logging.ERROR, logger="judoscale")
+
+        call_count = {"n": 0}
+
+        def fail_first_then_stop():
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("kaboom")
+            reporter._stopevent.set()
+
+        reporter._report_metrics = MagicMock(side_effect=fail_first_then_stop)
+        reporter.start()
+        reporter._thread.join(timeout=2)
+
+        assert call_count["n"] >= 2
+        assert any(
+            "Reporter cycle failed" in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary

Closes [JDO-1362](https://linear.app/judo/issue/JDO-1362/reporter-thread-dies-on-a-single-collector-exception).

Today, if any `collector.collect()` raises, the exception propagates all the way through `_run_loop` and **kills the reporter thread for the lifetime of the process** — silently disabling all metric reporting (across every adapter) until the dyno restarts.

We hit this in the wild on a customer's Celery + Heroku TLS Redis setup where `inspect.active()` (triggered by `TRACK_BUSY_JOBS=True`) blew up with an SSL handshake error. The stack trace ended at `threading.py:1012, in run` — the reporter thread was gone. See the linked Plain thread on JDO-1362 for context.

This PR adds two defensive layers in `judoscale/core/reporter.py`:

1. **`all_metrics`** now wraps each `collector.collect()` in try/except, logs the failing collector by class name with a full traceback, and continues with the rest. One bad collector no longer takes down the others.
2. **`_run_loop`** now wraps `_report_metrics()` in try/except so any unanticipated error in a reporting cycle is logged but the thread survives and tries again on the next interval.

Separately, JDO-1363 tracks investigating the actual SSL/pidbox root cause.

## Test plan

- [x] Added `test_all_metrics_continues_when_one_collector_raises` — a failing collector raises `RuntimeError`, a healthy collector still produces its metric, and the failure is logged.
- [x] Added `test_run_loop_survives_report_metrics_exception` — `_report_metrics` raises on the first cycle; the run loop runs another cycle (proving the thread is alive) before being stopped cleanly.
- [x] Full suite passes locally (137/137) with all extras installed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core metrics reporting resilience by swallowing/logging exceptions in the reporter loop and per-collector collection; risk is moderate because it can mask unexpected failures and alters runtime behavior of the background thread.
> 
> **Overview**
> Improves reporter robustness by **preventing metric reporting from stopping** when unexpected exceptions occur.
> 
> The reporter `_run_loop` now wraps `_report_metrics()` in a broad `try/except` to log failures and continue on the next interval, and `all_metrics` now logs and skips individual collectors whose `collect()` raises so other collectors still report.
> 
> Adds tests covering continued metric collection when one collector fails and ensuring the reporter thread survives a `_report_metrics` exception.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 330f4093add7edda224b295520df5ab2a0a235fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->