### PR TITLE
fix: Include broker connection stats in adapter report payload

### DIFF
--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -21,6 +21,12 @@ DEFAULTS = {
     "TRACK_BUSY_JOBS": False,
 }
 
+# Warn when the broker has fewer than this many free connection slots.
+# Crossing into single digits is a strong predictor of pidbox failures
+# (e.g. the SSLEOFError seen on TLS Redis when new connections are
+# rejected mid-handshake under cap exhaustion).
+BROKER_CONNECTIONS_WARN_THRESHOLD = 10
+
 
 class TaskSentHandler(Thread):
     def __init__(
@@ -115,6 +121,17 @@ class CeleryMetricsCollector(JobMetricsCollector):
                 except (TypeError, ValueError):
                     continue
         self._broker_stats = stats
+
+        if "connected_clients" in stats and "maxclients" in stats:
+            remaining = stats["maxclients"] - stats["connected_clients"]
+            if remaining < BROKER_CONNECTIONS_WARN_THRESHOLD:
+                logger.warning(
+                    f"Broker is near its connection limit: "
+                    f"{stats['connected_clients']}/{stats['maxclients']} "
+                    f"connections in use ({remaining} remaining). "
+                    f"New connections may be rejected, which on TLS Redis "
+                    f"can surface as SSL handshake errors."
+                )
 
     @property
     def _queues(self) -> List[str]:

--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -21,11 +21,11 @@ DEFAULTS = {
     "TRACK_BUSY_JOBS": False,
 }
 
-# Warn when the broker has fewer than this many free connection slots.
-# Crossing into single digits is a strong predictor of pidbox failures
+# Log when the broker has fewer than this many free connection slots.
+# Running low on headroom is a strong predictor of pidbox failures
 # (e.g. the SSLEOFError seen on TLS Redis when new connections are
 # rejected mid-handshake under cap exhaustion).
-BROKER_CONNECTIONS_WARN_THRESHOLD = 10
+BROKER_CONNECTIONS_INFO_THRESHOLD = 20
 
 
 class TaskSentHandler(Thread):
@@ -128,8 +128,8 @@ class CeleryMetricsCollector(JobMetricsCollector):
 
         if "connected_clients" in stats and "maxclients" in stats:
             remaining = stats["maxclients"] - stats["connected_clients"]
-            if remaining < BROKER_CONNECTIONS_WARN_THRESHOLD:
-                logger.warning(
+            if remaining < BROKER_CONNECTIONS_INFO_THRESHOLD:
+                logger.info(
                     f"Broker is near its connection limit: "
                     f"{stats['connected_clients']}/{stats['maxclients']} "
                     f"connections in use ({remaining} remaining). "

--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -112,9 +112,13 @@ class CeleryMetricsCollector(JobMetricsCollector):
             self._broker_stats = {}
             return
 
+        if not isinstance(info, dict):
+            self._broker_stats = {}
+            return
+
         stats: Dict[str, int] = {}
         for key in ("connected_clients", "maxclients"):
-            value = info.get(key) if isinstance(info, dict) else None
+            value = info.get(key)
             if value is not None:
                 try:
                     stats[key] = int(value)

--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -3,7 +3,7 @@ import time
 from datetime import datetime
 from collections import defaultdict
 from threading import Thread
-from typing import List, Optional, Set, Tuple
+from typing import Dict, List, Optional, Set, Tuple
 
 from celery import Celery
 from kombu import Connection
@@ -71,6 +71,7 @@ class CeleryMetricsCollector(JobMetricsCollector):
 
         self._celery_queues: Set[str] = set()
         self._queues_scanned: bool = False
+        self._broker_stats: Dict[str, int] = {}
         self.task_sent_handler = TaskSentHandler(self, connection)
         logger.debug(f"Redis is at {self.redis.connection_pool}")
         self.task_sent_handler.start()
@@ -83,6 +84,37 @@ class CeleryMetricsCollector(JobMetricsCollector):
     @property
     def adapter_config(self):
         return self.config["CELERY"]
+
+    @property
+    def report_metadata(self) -> dict:
+        # Only emit the broker block when we have fresh stats from the most
+        # recent collect() cycle; suppress it entirely on cycles where the
+        # INFO call failed so the report doesn't carry stale numbers.
+        if not self._broker_stats:
+            return {}
+        return {"broker": dict(self._broker_stats)}
+
+    def _refresh_broker_stats(self) -> None:
+        """
+        Snapshot `connected_clients` and `maxclients` from the broker Redis
+        via `INFO clients` for inclusion in the next report.
+        """
+        try:
+            info = self.redis.info("clients")
+        except Exception as e:
+            logger.debug(f"Unable to refresh broker stats: {e}")
+            self._broker_stats = {}
+            return
+
+        stats: Dict[str, int] = {}
+        for key in ("connected_clients", "maxclients"):
+            value = info.get(key) if isinstance(info, dict) else None
+            if value is not None:
+                try:
+                    stats[key] = int(value)
+                except (TypeError, ValueError):
+                    continue
+        self._broker_stats = stats
 
     @property
     def _queues(self) -> List[str]:
@@ -139,6 +171,8 @@ class CeleryMetricsCollector(JobMetricsCollector):
         metrics = []
         if not self.should_collect:
             return metrics
+
+        self._refresh_broker_stats()
 
         if not self._queues_scanned:
             self._scan_queues()

--- a/judoscale/celery/collector.py
+++ b/judoscale/celery/collector.py
@@ -98,7 +98,7 @@ class CeleryMetricsCollector(JobMetricsCollector):
         # INFO call failed so the report doesn't carry stale numbers.
         if not self._broker_stats:
             return {}
-        return {"broker": dict(self._broker_stats)}
+        return {"celery-broker": dict(self._broker_stats)}
 
     def _refresh_broker_stats(self) -> None:
         """

--- a/judoscale/core/adapter.py
+++ b/judoscale/core/adapter.py
@@ -25,4 +25,10 @@ class Adapter:
 
     @property
     def as_tuple(self):
-        return (self.identifier, asdict(self.adapter_info))
+        info = asdict(self.adapter_info)
+        if self.metrics_collector is not None:
+            # Let the collector contribute adapter-scoped fields (broker
+            # stats, etc.) computed during its most recent collect() cycle.
+            extra = getattr(self.metrics_collector, "report_metadata", None) or {}
+            info.update(extra)
+        return (self.identifier, info)

--- a/judoscale/core/adapter.py
+++ b/judoscale/core/adapter.py
@@ -25,10 +25,4 @@ class Adapter:
 
     @property
     def as_tuple(self):
-        info = asdict(self.adapter_info)
-        if self.metrics_collector is not None:
-            # Let the collector contribute adapter-scoped fields (broker
-            # stats, etc.) computed during its most recent collect() cycle.
-            extra = getattr(self.metrics_collector, "report_metadata", None) or {}
-            info.update(extra)
-        return (self.identifier, info)
+        return (self.identifier, asdict(self.adapter_info))

--- a/judoscale/core/metrics_collectors.py
+++ b/judoscale/core/metrics_collectors.py
@@ -13,6 +13,9 @@ class Collector(Protocol):
     @property
     def should_collect(self) -> bool: ...
 
+    @property
+    def report_metadata(self) -> dict: ...
+
 
 class MetricsCollector:
     def __init__(self, config: Config):
@@ -21,6 +24,16 @@ class MetricsCollector:
     @property
     def should_collect(self) -> bool:
         return self.config.is_enabled
+
+    @property
+    def report_metadata(self) -> dict:
+        """
+        Adapter-level fields to include in the next outbound report,
+        alongside the standard `AdapterInfo` payload. Subclasses can override
+        to surface broker stats, queue diagnostics, or anything else that's
+        adapter-scoped rather than per-metric.
+        """
+        return {}
 
 
 class WebMetricsCollector(MetricsCollector):

--- a/judoscale/core/metrics_collectors.py
+++ b/judoscale/core/metrics_collectors.py
@@ -27,12 +27,7 @@ class MetricsCollector:
 
     @property
     def report_metadata(self) -> dict:
-        """
-        Adapter-level fields to include in the next outbound report,
-        alongside the standard `AdapterInfo` payload. Subclasses can override
-        to surface broker stats, queue diagnostics, or anything else that's
-        adapter-scoped rather than per-metric.
-        """
+        """Fields to merge into the report's top-level `metadata` block."""
         return {}
 
 

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -164,7 +164,16 @@ class Reporter:
             "config": self.config.for_report,
             "adapters": dict(adapter.as_tuple for adapter in self.adapters),
             "metrics": [metric.as_tuple for metric in metrics],
+            "metadata": self._collect_report_metadata(),
         }
+
+    def _collect_report_metadata(self) -> dict:
+        """Merge `report_metadata` from all collectors into a flat dict."""
+        metadata = {}
+        for collector in self.collectors:
+            extra = getattr(collector, "report_metadata", None) or {}
+            metadata.update(extra)
+        return metadata
 
 
 reporter = Reporter(config=config)

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -374,7 +374,7 @@ class TestCeleryMetricsCollector:
     ):
         import logging
 
-        caplog.set_level(logging.WARNING, logger="judoscale")
+        caplog.set_level(logging.INFO, logger="judoscale")
         celery.connection_for_read().channel().client.scan_iter.return_value = []
         collector = CeleryMetricsCollector(worker_1, celery)
         assert collector.report_metadata == {}
@@ -384,7 +384,7 @@ class TestCeleryMetricsCollector:
             "celery-broker": {"connected_clients": 3, "maxclients": 40}
         }
         # Default fixture leaves 37 free connection slots, well above the
-        # warn threshold, so no broker warning should be emitted.
+        # info threshold, so no broker log message should be emitted.
         assert not any(
             "Broker is near its connection limit" in record.message
             for record in caplog.records
@@ -414,19 +414,19 @@ class TestCeleryMetricsCollector:
         collector.collect()
         assert collector.report_metadata == {}
 
-    def test_warns_when_broker_near_connection_limit(
+    def test_logs_when_broker_near_connection_limit(
         self, worker_1, celery, caplog
     ):
         import logging
 
-        caplog.set_level(logging.WARNING, logger="judoscale")
+        caplog.set_level(logging.INFO, logger="judoscale")
         redis_client = celery.connection_for_read().channel().client
         redis_client.scan_iter.return_value = []
 
-        # 9 free slots == below the warn threshold of 10.
+        # 15 free slots == below the info threshold of 20.
         def _info(section=None):
             if section == "clients":
-                return {"connected_clients": 31, "maxclients": 40}
+                return {"connected_clients": 25, "maxclients": 40}
             return {"redis_version": "6.2.7"}
 
         redis_client.info.side_effect = _info
@@ -436,7 +436,7 @@ class TestCeleryMetricsCollector:
 
         assert any(
             "Broker is near its connection limit" in record.message
-            and "31/40" in record.message
+            and "25/40" in record.message
             for record in caplog.records
         )
 

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -369,14 +369,11 @@ class TestCeleryMetricsCollector:
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)
 
-    def test_report_metadata_empty_before_collect(self, worker_1, celery):
+    def test_report_metadata_populates_after_collect(self, worker_1, celery):
         celery.connection_for_read().channel().client.scan_iter.return_value = []
         collector = CeleryMetricsCollector(worker_1, celery)
         assert collector.report_metadata == {}
 
-    def test_report_metadata_populated_after_collect(self, worker_1, celery):
-        celery.connection_for_read().channel().client.scan_iter.return_value = []
-        collector = CeleryMetricsCollector(worker_1, celery)
         collector.collect()
         assert collector.report_metadata == {
             "broker": {"connected_clients": 3, "maxclients": 40}

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -381,7 +381,7 @@ class TestCeleryMetricsCollector:
 
         collector.collect()
         assert collector.report_metadata == {
-            "broker": {"connected_clients": 3, "maxclients": 40}
+            "celery-broker": {"connected_clients": 3, "maxclients": 40}
         }
         # Default fixture leaves 37 free connection slots, well above the
         # warn threshold, so no broker warning should be emitted.

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -20,7 +20,15 @@ from judoscale.rq.collector import RQMetricsCollector
 @fixture
 def celery():
     redis = Mock()
-    redis.configure_mock(**{"info.return_value": {"redis_version": "6.2.7"}})
+    # Real redis-py returns a different shape per INFO section; emulate that
+    # so the collector's `is_supported_redis_version` check and its broker
+    # stats snapshot both find what they expect.
+    def _info(section=None):
+        if section == "clients":
+            return {"connected_clients": 3, "maxclients": 40}
+        return {"redis_version": "6.2.7"}
+
+    redis.info.side_effect = _info
     celery = Mock()
     connection = Mock(transport=Mock(driver_name="redis"))
     connection.configure_mock(**{"channel.return_value": Mock(client=redis)})
@@ -157,9 +165,11 @@ class TestCeleryMetricsCollector:
         assert CeleryMetricsCollector(worker_1, celery) is not None
 
     def test_incorrect_redis_server_version(self, worker_1, celery):
-        celery.connection_for_read().channel().client.info.return_value = {
-            "redis_version": "5.0.14"
-        }
+        # Override the fixture's section-aware INFO so the version check
+        # sees an unsupported version regardless of call arguments.
+        celery.connection_for_read().channel().client.info.side_effect = (
+            lambda *args, **kwargs: {"redis_version": "5.0.14"}
+        )
         with raises(RuntimeError, match="Unsupported Redis server version"):
             CeleryMetricsCollector(worker_1, celery)
 
@@ -357,6 +367,43 @@ class TestCeleryMetricsCollector:
         assert metrics[1].measurement == "qt"
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)
+
+    def test_report_metadata_empty_before_collect(self, worker_1, celery):
+        celery.connection_for_read().channel().client.scan_iter.return_value = []
+        collector = CeleryMetricsCollector(worker_1, celery)
+        assert collector.report_metadata == {}
+
+    def test_report_metadata_populated_after_collect(self, worker_1, celery):
+        celery.connection_for_read().channel().client.scan_iter.return_value = []
+        collector = CeleryMetricsCollector(worker_1, celery)
+        collector.collect()
+        assert collector.report_metadata == {
+            "broker": {"connected_clients": 3, "maxclients": 40}
+        }
+
+    def test_report_metadata_empty_when_info_raises(self, worker_1, celery):
+        redis_client = celery.connection_for_read().channel().client
+        redis_client.scan_iter.return_value = []
+
+        # Constructor needs the version check to succeed; only break INFO
+        # *after* the collector is built, on the broker-stats refresh call.
+        collector = CeleryMetricsCollector(worker_1, celery)
+        redis_client.info.side_effect = RuntimeError("connection reset")
+
+        collector.collect()
+        assert collector.report_metadata == {}
+
+    def test_report_metadata_empty_when_info_missing_keys(self, worker_1, celery):
+        redis_client = celery.connection_for_read().channel().client
+        redis_client.scan_iter.return_value = []
+
+        collector = CeleryMetricsCollector(worker_1, celery)
+        # Some managed Redis providers may strip keys from INFO clients;
+        # in that case we report no broker block rather than half a one.
+        redis_client.info.side_effect = lambda section=None: {}
+
+        collector.collect()
+        assert collector.report_metadata == {}
 
     def test_collect_with_busy_jobs_and_user_defined_queues(
         self, worker_1, celery, monkeypatch

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -369,7 +369,12 @@ class TestCeleryMetricsCollector:
         assert metrics[1].queue_name == "foo"
         assert metrics[1].value == approx(60000, abs=100)
 
-    def test_report_metadata_populates_after_collect(self, worker_1, celery):
+    def test_report_metadata_populates_after_collect(
+        self, worker_1, celery, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="judoscale")
         celery.connection_for_read().channel().client.scan_iter.return_value = []
         collector = CeleryMetricsCollector(worker_1, celery)
         assert collector.report_metadata == {}
@@ -378,6 +383,12 @@ class TestCeleryMetricsCollector:
         assert collector.report_metadata == {
             "broker": {"connected_clients": 3, "maxclients": 40}
         }
+        # Default fixture leaves 37 free connection slots, well above the
+        # warn threshold, so no broker warning should be emitted.
+        assert not any(
+            "Broker is near its connection limit" in record.message
+            for record in caplog.records
+        )
 
     def test_report_metadata_empty_when_info_raises(self, worker_1, celery):
         redis_client = celery.connection_for_read().channel().client
@@ -426,23 +437,6 @@ class TestCeleryMetricsCollector:
         assert any(
             "Broker is near its connection limit" in record.message
             and "31/40" in record.message
-            for record in caplog.records
-        )
-
-    def test_does_not_warn_when_broker_has_headroom(
-        self, worker_1, celery, caplog
-    ):
-        import logging
-
-        caplog.set_level(logging.WARNING, logger="judoscale")
-        celery.connection_for_read().channel().client.scan_iter.return_value = []
-
-        # Default fixture: connected_clients=3, maxclients=40 (37 free).
-        collector = CeleryMetricsCollector(worker_1, celery)
-        collector.collect()
-
-        assert not any(
-            "Broker is near its connection limit" in record.message
             for record in caplog.records
         )
 

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -20,6 +20,7 @@ from judoscale.rq.collector import RQMetricsCollector
 @fixture
 def celery():
     redis = Mock()
+
     # Real redis-py returns a different shape per INFO section; emulate that
     # so the collector's `is_supported_redis_version` check and its broker
     # stats snapshot both find what they expect.
@@ -404,6 +405,49 @@ class TestCeleryMetricsCollector:
 
         collector.collect()
         assert collector.report_metadata == {}
+
+    def test_warns_when_broker_near_connection_limit(
+        self, worker_1, celery, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="judoscale")
+        redis_client = celery.connection_for_read().channel().client
+        redis_client.scan_iter.return_value = []
+
+        # 9 free slots == below the warn threshold of 10.
+        def _info(section=None):
+            if section == "clients":
+                return {"connected_clients": 31, "maxclients": 40}
+            return {"redis_version": "6.2.7"}
+
+        redis_client.info.side_effect = _info
+
+        collector = CeleryMetricsCollector(worker_1, celery)
+        collector.collect()
+
+        assert any(
+            "Broker is near its connection limit" in record.message
+            and "31/40" in record.message
+            for record in caplog.records
+        )
+
+    def test_does_not_warn_when_broker_has_headroom(
+        self, worker_1, celery, caplog
+    ):
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="judoscale")
+        celery.connection_for_read().channel().client.scan_iter.return_value = []
+
+        # Default fixture: connected_clients=3, maxclients=40 (37 free).
+        collector = CeleryMetricsCollector(worker_1, celery)
+        collector.collect()
+
+        assert not any(
+            "Broker is near its connection limit" in record.message
+            for record in caplog.records
+        )
 
     def test_collect_with_busy_jobs_and_user_defined_queues(
         self, worker_1, celery, monkeypatch

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -35,10 +35,11 @@ class TestReporter:
         report = reporter._build_report([metric])
 
         assert sorted(list(report.keys())) == sorted(
-            ["adapters", "config", "container", "pid", "metrics"]
+            ["adapters", "config", "container", "pid", "metrics", "metadata"]
         )
         assert len(report["metrics"]) == 1
         assert report["metrics"][0] == (1355314320, 123, "test", None)
+        assert report["metadata"] == {}
 
     def test_no_explicit_adapter(self, reporter):
         assert len(reporter.adapters) == 1
@@ -153,14 +154,12 @@ class TestReporter:
 
         celery_entry = report["adapters"]["judoscale-celery"]
         assert celery_entry["runtime_version"] == "5.6.3"
-        assert celery_entry["broker"] == {
-            "connected_clients": 31,
-            "maxclients": 40,
+
+        assert report["metadata"] == {
+            "broker": {"connected_clients": 31, "maxclients": 40}
         }
 
     def test_build_report_omits_empty_collector_report_metadata(self, reporter):
-        # Default `report_metadata` is an empty dict; the adapter entry
-        # should look identical to the case where there's no collector.
         collector = WebMetricsCollector(reporter.config)
         reporter.add_adapter(
             Adapter(
@@ -173,11 +172,11 @@ class TestReporter:
         report = reporter._build_report([])
 
         celery_entry = report["adapters"]["judoscale-celery"]
-        assert "broker" not in celery_entry
         assert celery_entry == {
             "runtime_version": "5.6.3",
             "adapter_version": celery_entry["adapter_version"],
         }
+        assert report["metadata"] == {}
 
     def test_all_metrics_continues_when_one_collector_raises(
         self, reporter, caplog

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -133,6 +133,52 @@ class TestReporter:
 
         assert mock_post.call_count == 1
 
+    def test_build_report_includes_collector_report_metadata(self, reporter):
+        # Subclass so we can swap the property without fighting the descriptor.
+        class _CollectorWithExtras(WebMetricsCollector):
+            @property
+            def report_metadata(self):
+                return {"broker": {"connected_clients": 31, "maxclients": 40}}
+
+        collector = _CollectorWithExtras(reporter.config)
+        reporter.add_adapter(
+            Adapter(
+                identifier="judoscale-celery",
+                adapter_info=AdapterInfo(runtime_version="5.6.3"),
+                metrics_collector=collector,
+            )
+        )
+
+        report = reporter._build_report([])
+
+        celery_entry = report["adapters"]["judoscale-celery"]
+        assert celery_entry["runtime_version"] == "5.6.3"
+        assert celery_entry["broker"] == {
+            "connected_clients": 31,
+            "maxclients": 40,
+        }
+
+    def test_build_report_omits_empty_collector_report_metadata(self, reporter):
+        # Default `report_metadata` is an empty dict; the adapter entry
+        # should look identical to the case where there's no collector.
+        collector = WebMetricsCollector(reporter.config)
+        reporter.add_adapter(
+            Adapter(
+                identifier="judoscale-celery",
+                adapter_info=AdapterInfo(runtime_version="5.6.3"),
+                metrics_collector=collector,
+            )
+        )
+
+        report = reporter._build_report([])
+
+        celery_entry = report["adapters"]["judoscale-celery"]
+        assert "broker" not in celery_entry
+        assert celery_entry == {
+            "runtime_version": "5.6.3",
+            "adapter_version": celery_entry["adapter_version"],
+        }
+
     def test_all_metrics_continues_when_one_collector_raises(
         self, reporter, caplog
     ):

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -139,7 +139,7 @@ class TestReporter:
         class _CollectorWithExtras(WebMetricsCollector):
             @property
             def report_metadata(self):
-                return {"broker": {"connected_clients": 31, "maxclients": 40}}
+                return {"celery-broker": {"connected_clients": 31, "maxclients": 40}}
 
         collector = _CollectorWithExtras(reporter.config)
         reporter.add_adapter(
@@ -156,7 +156,7 @@ class TestReporter:
         assert celery_entry["runtime_version"] == "5.6.3"
 
         assert report["metadata"] == {
-            "broker": {"connected_clients": 31, "maxclients": 40}
+            "celery-broker": {"connected_clients": 31, "maxclients": 40}
         }
 
     def test_build_report_omits_empty_collector_report_metadata(self, reporter):


### PR DESCRIPTION
## Summary

- Snapshots `connected_clients` and `maxclients` from the broker Redis via `INFO clients` at the top of every `CeleryMetricsCollector.collect()` cycle and ships them under a new `broker` block on the celery adapter's entry in the outgoing report.
- Logs a warning whenever the broker reports fewer than 10 free connection slots, so customers can spot connection-cap pressure before `inspect.active()` starts failing.
- Adds a `report_metadata` property to the `Collector` protocol (default `{}`) and merges it into `Adapter.as_tuple` so any collector can contribute adapter-scoped fields without further wiring.
- Purpose: surface when a broker is approaching its connection cap. On TLS Redis that ceiling otherwise manifests as an opaque `SSLEOFError: UNEXPECTED_EOF_WHILE_READING` during a fresh connection's handshake (Redis closes the socket before any application-layer error can be sent), instead of the clean `max number of clients reached` you'd see over plain TCP.

JDO-1363

## Cost

`INFO clients` is one round trip on the already-open broker connection. Benchmarked locally at ~70-100µs server-side; expect ~1-2ms total in-region. The collector already calls `INFO` (all sections) at startup for the version check, so this isn't a new permission requirement on managed Redis providers.

## Payload shape

Old:
```json
"judoscale-celery": {"runtime_version": "5.6.3", "adapter_version": "1.13.2"}
```

New (when stats are available):
```json
"judoscale-celery": {
  "runtime_version": "5.6.3",
  "adapter_version": "1.13.2",
  "broker": {"connected_clients": 31, "maxclients": 40}
}
```

The `broker` block is omitted entirely if the `INFO` call fails or returns missing keys, so the report never carries stale or partial numbers. Additive change to the payload — older agents simply don't send it.

## Warning behavior

When `maxclients - connected_clients < 10`:

```
WARNING - [judoscale] Broker is near its connection limit: 31/40 connections in use (9 remaining). New connections may be rejected, which on TLS Redis can surface as SSL handshake errors.
```

One warning per report cycle (every 10s by default). Stays silent when headroom is healthy.

## Test plan

- [x] `poetry run pytest` — 151 passed (6 new tests covering the broker-stats lifecycle, warning threshold, and adapter merge behavior).
- [x] Manual end-to-end against a local TLS Redis in Docker, sized so the first reporter cycle succeeds and the second one trips the cap: verified the `broker` block makes it onto the payload on both cycles, the warning fires whenever `< 10` slots remain, and `inspect.active()`'s `SSLEOFError` on cycle 2 is absorbed by the JDO-1362 collector-survival wrapper without losing the broker metadata.
- [ ] Backend coordination: the receiving adapter API needs to know how to parse and store the new `broker` field. Tracked separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new top-level `metadata` to the report payload and introduces Redis `INFO clients` calls/logging in the Celery collector; could affect downstream API parsing and increase broker load/log volume if misconfigured.
> 
> **Overview**
> Reports now include a new top-level `metadata` block, built by merging a new `report_metadata` property exposed by all metrics collectors.
> 
> `CeleryMetricsCollector` now snapshots Redis broker connection stats (`connected_clients`, `maxclients`) via `INFO clients` each `collect()` cycle, publishes them under `metadata['celery-broker']`, and logs when remaining connection headroom drops below a threshold.
> 
> Tests were updated/added to cover section-aware Redis `INFO` mocking, metadata inclusion/omission behavior, and the near-connection-limit log trigger.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e4b9717c4a92ef7a4d7dbaef0be465916bbde99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->