### PR TITLE
fix: Read Scalingo container identity from CONTAINER env var

### DIFF
--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import re
 from collections import UserDict
 from typing import Mapping
 
@@ -9,10 +10,15 @@ DEFAULTS = {"REPORT_INTERVAL_SECONDS": 10, "LOG_LEVEL": "WARN"}
 
 
 class RuntimeContainer(str):
+    # Job metrics are collected from a single container per process type when we
+    # can identify the ordinal instance (Heroku "web.2", Scalingo "web-2").
+    # Opaque IDs (Render, ECS, Railway, etc.) are always non-redundant.
+    ORDINAL_CONTAINER = re.compile(r"\A[a-z_]+[.-](\d{1,3})\Z")
+
     @property
     def is_redundant_instance(self):
-        instance_number = self.split(".")[-1]
-        return instance_number.isdigit() and int(instance_number) > 1
+        match = self.ORDINAL_CONTAINER.match(self)
+        return bool(match) and int(match.group(1)) > 1
 
     @property
     def is_release_instance(self):
@@ -56,6 +62,9 @@ class Config(UserDict):
             container = env["FLY_MACHINE_ID"]
         elif env.get("RAILWAY_REPLICA_ID"):
             container = env["RAILWAY_REPLICA_ID"]
+        elif env.get("CONTAINER"):
+            # Scalingo exposes the container type and index (e.g. "web-1").
+            container = env["CONTAINER"]
         else:
             container = ""
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,15 +40,19 @@ def heroku_worker_2(monkeypatch):
 
 @fixture
 def render_web(monkeypatch):
-    monkeypatch.setenv("RENDER_SERVICE_ID", "srv-123")
-    monkeypatch.setenv("RENDER_INSTANCE_ID", "srv-123-abc-def")
+    monkeypatch.setenv("RENDER_SERVICE_ID", "srv-cretl9aj1k6c73a9b6lg")
+    monkeypatch.setenv(
+        "RENDER_INSTANCE_ID", "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-kb6kj"
+    )
     return Config.initialize()
 
 
 @fixture
 def render_worker(monkeypatch):
-    monkeypatch.setenv("RENDER_SERVICE_ID", "srv-123")
-    monkeypatch.setenv("RENDER_INSTANCE_ID", "srv-123-abc-def")
+    monkeypatch.setenv("RENDER_SERVICE_ID", "srv-cretl9aj1k6c73a9b6lg")
+    monkeypatch.setenv(
+        "RENDER_INSTANCE_ID", "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-2dptk"
+    )
     return Config.initialize()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -52,21 +52,65 @@ def render_worker(monkeypatch):
     return Config.initialize()
 
 
-@fixture(params=["heroku_web_1", "heroku_web_2", "render_web"])
+@fixture
+def scalingo_web_1(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
+    monkeypatch.setenv("CONTAINER", "web-1")
+    return Config.initialize()
+
+
+@fixture
+def scalingo_web_2(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
+    monkeypatch.setenv("CONTAINER", "web-2")
+    return Config.initialize()
+
+
+@fixture
+def scalingo_worker_1(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
+    monkeypatch.setenv("CONTAINER", "worker-1")
+    return Config.initialize()
+
+
+@fixture
+def scalingo_worker_2(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
+    monkeypatch.setenv("CONTAINER", "worker-2")
+    return Config.initialize()
+
+
+@fixture(
+    params=[
+        "heroku_web_1",
+        "heroku_web_2",
+        "render_web",
+        "scalingo_web_1",
+        "scalingo_web_2",
+    ]
+)
 def web_all(request):
     return request.getfixturevalue(request.param)
 
 
-@fixture(params=["heroku_web_1", "render_web"])
+@fixture(params=["heroku_web_1", "render_web", "scalingo_web_1"])
 def web_1(request):
     return request.getfixturevalue(request.param)
 
 
-@fixture(params=["heroku_worker_1", "heroku_worker_2", "render_worker"])
+@fixture(
+    params=[
+        "heroku_worker_1",
+        "heroku_worker_2",
+        "render_worker",
+        "scalingo_worker_1",
+        "scalingo_worker_2",
+    ]
+)
 def worker_all(request):
     return request.getfixturevalue(request.param)
 
 
-@fixture(params=["heroku_worker_1", "render_worker"])
+@fixture(params=["heroku_worker_1", "render_worker", "scalingo_worker_1"])
 def worker_1(request):
     return request.getfixturevalue(request.param)

--- a/tests/test_collectors.py
+++ b/tests/test_collectors.py
@@ -102,6 +102,10 @@ class TestJobMetricsCollector:
         monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"ENABLED": True})
         assert not JobMetricsCollector(heroku_worker_2).should_collect
 
+    def test_should_not_collect_scalingo_worker_2(self, scalingo_worker_2, monkeypatch):
+        monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"ENABLED": True})
+        assert not JobMetricsCollector(scalingo_worker_2).should_collect
+
     def test_limit_max_queues_under_limit(self, web_1, monkeypatch):
         monkeypatch.setattr(JobMetricsCollector, "adapter_config", {"MAX_QUEUES": 2})
         collector = JobMetricsCollector(web_1)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,30 +19,33 @@ class TestConfig:
 
     def test_on_render(self):
         fake_env = {
-            "RENDER_SERVICE_ID": "srv-123",
-            "RENDER_INSTANCE_ID": "srv-123-abc-456",
+            "RENDER_SERVICE_ID": "srv-cretl9aj1k6c73a9b6lg",
+            "RENDER_INSTANCE_ID": "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-kb6kj",
             "RENDER_SERVICE_TYPE": "web",
             "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
             "LOG_LEVEL": "WARN",
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "abc-456"
+        assert config["RUNTIME_CONTAINER"] == "5c686f7df6-kb6kj"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
     def test_on_render_legacy(self):
         fake_env = {
-            "RENDER_SERVICE_ID": "srv-123",
-            "RENDER_INSTANCE_ID": "srv-123-abc-456",
+            "RENDER_SERVICE_ID": "srv-cretl9aj1k6c73a9b6lg",
+            "RENDER_INSTANCE_ID": "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-kb6kj",
             "RENDER_SERVICE_TYPE": "web",
             "LOG_LEVEL": "WARN",
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "abc-456"
+        assert config["RUNTIME_CONTAINER"] == "5c686f7df6-kb6kj"
         assert config["LOG_LEVEL"] == "WARN"
-        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/srv-123"
+        assert (
+            config["API_BASE_URL"]
+            == "https://adapter.judoscale.com/api/srv-cretl9aj1k6c73a9b6lg"
+        )
 
     def test_on_ecs(self):
         fake_env = {
@@ -230,6 +233,8 @@ class TestRuntimeContainer:
             "5497f74465-m5wwr",
             "a8880ee042bc4db3ba878dce65b769b6-2750272591",
             "abcdef-2750272591",
+            "5c686f7df6-kb6kj",  # realistic Render container id
+            "5c686f7df6-2dptk",  # Render id with a digit-leading suffix
         ],
     )
     def test_opaque_container_ids_are_not_redundant(self, container_id):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,6 +82,18 @@ class TestConfig:
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
+    def test_on_scalingo(self):
+        fake_env = {
+            "CONTAINER": "web-1",
+            "JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890",
+            "LOG_LEVEL": "WARN",
+        }
+        config = Config.initialize(fake_env)
+
+        assert config["RUNTIME_CONTAINER"] == "web-1"
+        assert config["LOG_LEVEL"] == "WARN"
+        assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
+
     def test_on_custom(self):
         fake_env = {
             "JUDOSCALE_CONTAINER": "my-custom-container",
@@ -198,9 +210,30 @@ class TestConfig:
 
 
 class TestRuntimeContainer:
-    def test_is_redundant_instance(self):
-        container = RuntimeContainer("web.2")
-        assert container.is_redundant_instance
+    @pytest.mark.parametrize(
+        "container_id",
+        ["web.1", "worker.1", "custom_name.1", "web-1", "worker-1", "tcp-1"],
+    )
+    def test_is_not_redundant_instance(self, container_id):
+        assert not RuntimeContainer(container_id).is_redundant_instance
+
+    @pytest.mark.parametrize(
+        "container_id",
+        ["web.2", "worker.8", "custom_name.15", "web-2", "worker-8", "tcp-2"],
+    )
+    def test_is_redundant_instance(self, container_id):
+        assert RuntimeContainer(container_id).is_redundant_instance
+
+    @pytest.mark.parametrize(
+        "container_id",
+        [
+            "5497f74465-m5wwr",
+            "a8880ee042bc4db3ba878dce65b769b6-2750272591",
+            "abcdef-2750272591",
+        ],
+    )
+    def test_opaque_container_ids_are_not_redundant(self, container_id):
+        assert not RuntimeContainer(container_id).is_redundant_instance
 
     def test_is_release_instance(self):
         container = RuntimeContainer("release.1")
@@ -209,10 +242,6 @@ class TestRuntimeContainer:
     def test_is_release_instance_2(self):
         container = RuntimeContainer("release.2")
         assert container.is_release_instance
-
-    def test_is_not_redundant_instance(self):
-        container = RuntimeContainer("web.1")
-        assert not container.is_redundant_instance
 
     def test_string_representation(self):
         container = RuntimeContainer("web.1")


### PR DESCRIPTION
## Summary

Ports [judoscale-ruby#271](https://github.com/judoscale/judoscale-ruby/pull/271) to the Python package.

- Detect the runtime container from Scalingo's `CONTAINER` env var (e.g. `web-1`, `worker-1`) so adapter reports include real container metadata instead of `""`.
- Generalize redundant-instance detection via an `ORDINAL_CONTAINER` regex (`\A[a-z_]+[.-](\d{1,3})\Z`) that covers both Heroku-style (`web.2`) and Scalingo-style (`web-2`) ordinals, skipping job-metrics collection on instances beyond the first.
- Cap the ordinal suffix at 1-3 digits so opaque IDs (Render, ECS, Railway, Fly) with long numeric tails stay non-redundant.

## Notes

- Behavior parity caveat: the old logic used `split(".")[-1]`, so a name like `web.staging.2` was treated as redundant; the new regex (matching Ruby) treats it as non-redundant.

## Test plan

- [x] `poetry run pytest` passes (209 tests), including new Scalingo config init, redundant/non-redundant/opaque `RuntimeContainer` cases, and `scalingo_worker_2` collection gating.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which processes report job metrics (ordinal gating) and container identity for Scalingo; behavior shifts for multi-segment names like `web.staging.2` vs the old dot-split logic.
> 
> **Overview**
> Adds **Scalingo** support by reading `CONTAINER` (e.g. `web-1`) into `RUNTIME_CONTAINER`, and replaces redundant-instance detection with an **`ORDINAL_CONTAINER`** regex so Heroku (`web.2`) and Scalingo (`web-2`) ordinals skip job metrics on instances after the first while **opaque** platform IDs (Render, ECS, etc.) stay non-redundant.
> 
> Tests add Scalingo fixtures, realistic Render container IDs, and parametrize `RuntimeContainer` redundancy cases; job collector tests assert `worker-2` on Scalingo does not collect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17f58de2040b042ea86e2199ec63bc6521bd0bdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->