### PR TITLE
refactor: Model the hosting platform with per-platform classes

### DIFF
--- a/judoscale/core/config.py
+++ b/judoscale/core/config.py
@@ -1,38 +1,19 @@
 import logging
 import os
-import re
 from collections import UserDict
 from typing import Mapping
 
 from judoscale.core.logger import logger
+from judoscale.core.platform import Platform
 
 DEFAULTS = {"REPORT_INTERVAL_SECONDS": 10, "LOG_LEVEL": "WARN"}
 
 
-class RuntimeContainer(str):
-    # Job metrics are collected from a single container per process type when we
-    # can identify the ordinal instance (Heroku "web.2", Scalingo "web-2").
-    # Opaque IDs (Render, ECS, Railway, etc.) are always non-redundant.
-    ORDINAL_CONTAINER = re.compile(r"\A[a-z_]+[.-](\d{1,3})\Z")
-
-    @property
-    def is_redundant_instance(self):
-        match = self.ORDINAL_CONTAINER.match(self)
-        return bool(match) and int(match.group(1)) > 1
-
-    @property
-    def is_release_instance(self):
-        # NOTE: this is currently Heroku-specific. We may need to update this
-        # for other platforms in the future and possibly move it to the Config
-        # module.
-        return self.lower().startswith("release")
-
-
 class Config(UserDict):
-    def __init__(self, runtime_container: RuntimeContainer, env: Mapping):
+    def __init__(self, platform: Platform, env: Mapping):
         initialdata = dict(
             DEFAULTS,
-            RUNTIME_CONTAINER=runtime_container,
+            PLATFORM=platform,
             API_BASE_URL=env.get("JUDOSCALE_URL"),
         )
 
@@ -44,37 +25,17 @@ class Config(UserDict):
             "JUDOSCALE_LOG_LEVEL", env.get("LOG_LEVEL", initialdata["LOG_LEVEL"])
         )
 
+        # Legacy Render services not using JUDOSCALE_URL derive the API url from
+        # the platform.
+        if not initialdata["API_BASE_URL"]:
+            initialdata["API_BASE_URL"] = platform.default_api_base_url
+
         super().__init__(initialdata)
         self._prepare_logging()
 
     @classmethod
     def initialize(cls, env: Mapping = os.environ):
-        if env.get("JUDOSCALE_CONTAINER"):
-            container = env["JUDOSCALE_CONTAINER"]
-        elif env.get("DYNO"):
-            container = env["DYNO"]
-        elif env.get("RENDER_INSTANCE_ID"):
-            service_id = env.get("RENDER_SERVICE_ID")
-            container = env["RENDER_INSTANCE_ID"].replace(f"{service_id}-", "")
-        elif env.get("ECS_CONTAINER_METADATA_URI"):
-            container = env["ECS_CONTAINER_METADATA_URI"].split("/")[-1]
-        elif env.get("FLY_MACHINE_ID"):
-            container = env["FLY_MACHINE_ID"]
-        elif env.get("RAILWAY_REPLICA_ID"):
-            container = env["RAILWAY_REPLICA_ID"]
-        elif env.get("CONTAINER"):
-            # Scalingo exposes the container type and index (e.g. "web-1").
-            container = env["CONTAINER"]
-        else:
-            container = ""
-
-        config = cls(RuntimeContainer(container), env)
-
-        # Render legacy support: fall back to constructing URL from service ID
-        if not config["API_BASE_URL"] and env.get("RENDER_SERVICE_ID"):
-            config["API_BASE_URL"] = f"https://adapter.judoscale.com/api/{env['RENDER_SERVICE_ID']}"
-
-        return config
+        return cls(Platform.detect(env), env)
 
     @property
     def is_enabled(self) -> bool:

--- a/judoscale/core/metrics_collectors.py
+++ b/judoscale/core/metrics_collectors.py
@@ -83,7 +83,7 @@ class JobMetricsCollector(MetricsCollector):
         return (
             super().should_collect
             and self.adapter_config["ENABLED"]
-            and not self.config["RUNTIME_CONTAINER"].is_redundant_instance
+            and not self.config["PLATFORM"].is_redundant_instance
         )
 
     def limit_max_queues(self, queues: List[str]) -> Set[str]:

--- a/judoscale/core/platform.py
+++ b/judoscale/core/platform.py
@@ -1,0 +1,128 @@
+import os
+import re
+from typing import Mapping
+
+
+class Platform:
+    """The hosting platform we detected from the environment.
+
+    The container/instance id is just one property of the platform — behavior
+    that only applies to certain platforms (whether an instance is a redundant
+    member of a formation, or a release/build instance) lives on the platform
+    subclasses that actually have those concepts, instead of being re-derived
+    from the shape of the container string.
+    """
+
+    def __init__(self, container):
+        self.container = str(container)
+
+    @property
+    def is_redundant_instance(self) -> bool:
+        """Most platforms expose opaque, non-ordinal instance ids (Render, ECS,
+        Fly, Railway, custom), so by default no instance is redundant. Platforms
+        that have a formation ordinal override this."""
+        return False
+
+    @property
+    def is_release_instance(self) -> bool:
+        """Only Heroku has a release/build phase, so by default no instance is a
+        release instance."""
+        return False
+
+    @property
+    def default_api_base_url(self):
+        """Platforms may contribute a default API base url when one isn't configured."""
+        return None
+
+    @classmethod
+    def detect(cls, env: Mapping = os.environ) -> "Platform":
+        """Detect the current platform from the environment. Order matters: an
+        explicit JUDOSCALE_CONTAINER always wins, and Unknown is the fallback."""
+        if env.get("JUDOSCALE_CONTAINER"):
+            return Custom(env["JUDOSCALE_CONTAINER"])
+        elif env.get("DYNO"):
+            return Heroku(env["DYNO"])
+        elif env.get("RENDER_INSTANCE_ID"):
+            return Render(
+                env["RENDER_INSTANCE_ID"], service_id=env.get("RENDER_SERVICE_ID")
+            )
+        elif env.get("ECS_CONTAINER_METADATA_URI"):
+            return Ecs(env["ECS_CONTAINER_METADATA_URI"].split("/")[-1])
+        elif env.get("FLY_MACHINE_ID"):
+            return Fly(env["FLY_MACHINE_ID"])
+        elif env.get("RAILWAY_REPLICA_ID"):
+            return Railway(env["RAILWAY_REPLICA_ID"])
+        elif env.get("CONTAINER"):
+            # Scalingo exposes the container type and index (e.g. "web-1").
+            return Scalingo(env["CONTAINER"])
+        else:
+            return Unknown("")
+
+
+class Heroku(Platform):
+    # Heroku dynos are named "web.2". We collect metrics from a single container
+    # per process type, so any instance beyond the first is redundant — it would
+    # only duplicate the metrics the first instance already reports.
+    _ORDINAL = re.compile(r"[a-z_]+\.(\d+)")
+
+    @property
+    def is_redundant_instance(self) -> bool:
+        match = self._ORDINAL.fullmatch(self.container)
+        return int(match.group(1)) > 1 if match else False
+
+    @property
+    def is_release_instance(self) -> bool:
+        # Heroku release-phase dynos are named "release.1234".
+        return self.container.lower().startswith("release")
+
+
+class Scalingo(Platform):
+    # Scalingo containers are named "web-2", same redundancy rule as Heroku.
+    _ORDINAL = re.compile(r"[a-z_]+-(\d+)")
+
+    @property
+    def is_redundant_instance(self) -> bool:
+        match = self._ORDINAL.fullmatch(self.container)
+        return int(match.group(1)) > 1 if match else False
+
+
+class Render(Platform):
+    def __init__(self, instance_id, service_id=None):
+        self._service_id = service_id
+        # Render prefixes the instance id with the service id, which isn't part
+        # of the instance.
+        if service_id:
+            instance_id = instance_id.removeprefix(f"{service_id}-")
+        super().__init__(instance_id)
+
+    @property
+    def default_api_base_url(self):
+        # Legacy Render services not using JUDOSCALE_URL derive the adapter URL
+        # from the service id.
+        if self._service_id:
+            return f"https://adapter.judoscale.com/api/{self._service_id}"
+        return None
+
+
+class Ecs(Platform):
+    pass
+
+
+class Fly(Platform):
+    pass
+
+
+class Railway(Platform):
+    pass
+
+
+class Custom(Platform):
+    """User-provided container id via JUDOSCALE_CONTAINER."""
+
+    pass
+
+
+class Unknown(Platform):
+    """Unsupported or undetected platform."""
+
+    pass

--- a/judoscale/core/reporter.py
+++ b/judoscale/core/reporter.py
@@ -52,7 +52,7 @@ class Reporter:
             logger.info("Reporter not started: API_BASE_URL not set")
             return
 
-        if self.config["RUNTIME_CONTAINER"].is_release_instance:
+        if self.config["PLATFORM"].is_release_instance:
             logger.info("Reporter not started: in a build process")
             return
 
@@ -159,7 +159,7 @@ class Reporter:
 
     def _build_report(self, metrics: List[Metric]):
         return {
-            "container": str(self.config["RUNTIME_CONTAINER"]),
+            "container": self.config["PLATFORM"].container,
             "pid": self.pid,
             "config": self.config.for_report,
             "adapters": dict(adapter.as_tuple for adapter in self.adapters),

--- a/sample-apps/django_sample/tests/tests.py
+++ b/sample-apps/django_sample/tests/tests.py
@@ -3,7 +3,8 @@ from unittest import TestCase
 
 from django.test import Client
 
-from judoscale.core.config import config, RuntimeContainer
+from judoscale.core.config import config
+from judoscale.core.platform import Heroku
 from judoscale.core.reporter import reporter
 from judoscale.core.utilization_tracker import utilization_tracker
 
@@ -14,7 +15,7 @@ client = Client()
 
 class TestApp(TestCase):
     def setUp(self):
-        config["RUNTIME_CONTAINER"] = RuntimeContainer("web.1")
+        config["PLATFORM"] = Heroku("web.1")
 
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests

--- a/sample-apps/fastapi_sample/tests.py
+++ b/sample-apps/fastapi_sample/tests.py
@@ -4,7 +4,8 @@ import unittest
 from app.main import create_app
 from fastapi.testclient import TestClient
 
-from judoscale.core.config import config, RuntimeContainer
+from judoscale.core.config import config
+from judoscale.core.platform import Heroku
 from judoscale.core.reporter import reporter
 from judoscale.core.utilization_tracker import utilization_tracker
 
@@ -16,7 +17,7 @@ client = TestClient(app)
 
 class BasicTests(unittest.TestCase):
     def setUp(self):
-        config["RUNTIME_CONTAINER"] = RuntimeContainer("web.1")
+        config["PLATFORM"] = Heroku("web.1")
 
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests

--- a/sample-apps/flask_sample/tests.py
+++ b/sample-apps/flask_sample/tests.py
@@ -3,7 +3,8 @@ import unittest
 
 from app import create_app
 
-from judoscale.core.config import config, RuntimeContainer
+from judoscale.core.config import config
+from judoscale.core.platform import Heroku
 from judoscale.core.reporter import reporter
 from judoscale.core.utilization_tracker import utilization_tracker
 
@@ -17,7 +18,7 @@ client = app.test_client()
 
 class BasicTests(unittest.TestCase):
     def setUp(self):
-        config["RUNTIME_CONTAINER"] = RuntimeContainer("web.1")
+        config["PLATFORM"] = Heroku("web.1")
 
     def tearDown(self):
         # flush metrics to avoid them leaking to other tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,7 @@ def heroku_worker_2(monkeypatch):
 
 @fixture
 def render_web(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("RENDER_SERVICE_ID", "srv-cretl9aj1k6c73a9b6lg")
     monkeypatch.setenv(
         "RENDER_INSTANCE_ID", "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-kb6kj"
@@ -49,6 +50,7 @@ def render_web(monkeypatch):
 
 @fixture
 def render_worker(monkeypatch):
+    monkeypatch.setenv("JUDOSCALE_URL", "https://api.example.com")
     monkeypatch.setenv("RENDER_SERVICE_ID", "srv-cretl9aj1k6c73a9b6lg")
     monkeypatch.setenv(
         "RENDER_INSTANCE_ID", "srv-cretl9aj1k6c73a9b6lg-5c686f7df6-2dptk"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,17 @@
 import pytest
 
-from judoscale.core.config import Config, RuntimeContainer
+from judoscale.core.config import Config
+from judoscale.core.platform import (
+    Custom,
+    Ecs,
+    Fly,
+    Heroku,
+    Platform,
+    Railway,
+    Render,
+    Scalingo,
+    Unknown,
+)
 from judoscale.django.redis import RedisHelper
 
 
@@ -13,7 +24,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "web.1"
+        assert config["PLATFORM"].container == "web.1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -27,7 +38,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "5c686f7df6-kb6kj"
+        assert config["PLATFORM"].container == "5c686f7df6-kb6kj"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -40,12 +51,13 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "5c686f7df6-kb6kj"
+        assert config["PLATFORM"].container == "5c686f7df6-kb6kj"
         assert config["LOG_LEVEL"] == "WARN"
         assert (
             config["API_BASE_URL"]
             == "https://adapter.judoscale.com/api/srv-cretl9aj1k6c73a9b6lg"
         )
+        assert config.is_enabled
 
     def test_on_ecs(self):
         fake_env = {
@@ -55,7 +67,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
+        assert config["PLATFORM"].container == "a8880ee042bc4db3ba878dce65b769b6-2750272591"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -68,7 +80,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "683d924b322418"
+        assert config["PLATFORM"].container == "683d924b322418"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -81,7 +93,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
+        assert config["PLATFORM"].container == "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -93,7 +105,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "web-1"
+        assert config["PLATFORM"].container == "web-1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -104,7 +116,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "my-custom-container"
+        assert config["PLATFORM"].container == "my-custom-container"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -116,13 +128,13 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "my-custom-container"
+        assert config["PLATFORM"].container == "my-custom-container"
 
     def test_on_unknown(self):
         fake_env = {"JUDOSCALE_URL": "https://adapter.judoscale.com/api/1234567890"}
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == ""
+        assert config["PLATFORM"].container == ""
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://adapter.judoscale.com/api/1234567890"
 
@@ -135,15 +147,15 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
 
-        assert config["RUNTIME_CONTAINER"] == "web.1"
+        assert config["PLATFORM"].container == "web.1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["API_BASE_URL"] == "https://api.example.com"
 
     def test_is_enabled(self):
-        config = Config(RuntimeContainer(""), {})
+        config = Config(Unknown(""), {})
         assert not config.is_enabled
 
-        config = Config(RuntimeContainer(""), {"JUDOSCALE_URL": "https://some-url.com"})
+        config = Config(Unknown(""), {"JUDOSCALE_URL": "https://some-url.com"})
         assert config.is_enabled
 
     def test_for_report(self):
@@ -174,7 +186,7 @@ class TestConfig:
         }
         config = Config.initialize(fake_env)
         assert config["API_BASE_URL"] == "https://api.example.com"
-        assert config["RUNTIME_CONTAINER"] == "worker.1"
+        assert config["PLATFORM"].container == "worker.1"
         assert config["LOG_LEVEL"] == "WARN"
         assert config["REPORT_INTERVAL_SECONDS"] == 10
 
@@ -212,45 +224,83 @@ class TestConfig:
         assert config["REPORT_INTERVAL_SECONDS"] == 20
 
 
-class TestRuntimeContainer:
-    @pytest.mark.parametrize(
-        "container_id",
-        ["web.1", "worker.1", "custom_name.1", "web-1", "worker-1", "tcp-1"],
-    )
-    def test_is_not_redundant_instance(self, container_id):
-        assert not RuntimeContainer(container_id).is_redundant_instance
+class TestPlatform:
+    def test_detects_the_platform_from_env_with_custom_winning(self):
+        # An explicit JUDOSCALE_CONTAINER always wins over platform vars.
+        assert isinstance(
+            Platform.detect({"JUDOSCALE_CONTAINER": "x", "DYNO": "web.1"}), Custom
+        )
+        assert isinstance(Platform.detect({"DYNO": "web.1"}), Heroku)
+        assert isinstance(
+            Platform.detect(
+                {"RENDER_INSTANCE_ID": "srv-x-abc", "RENDER_SERVICE_ID": "srv-x"}
+            ),
+            Render,
+        )
+        assert isinstance(
+            Platform.detect(
+                {"ECS_CONTAINER_METADATA_URI": "http://169.254.170.2/v3/abc"}
+            ),
+            Ecs,
+        )
+        assert isinstance(Platform.detect({"FLY_MACHINE_ID": "683d924b322418"}), Fly)
+        assert isinstance(Platform.detect({"RAILWAY_REPLICA_ID": "f9c88b6e"}), Railway)
+        assert isinstance(Platform.detect({"CONTAINER": "web-1"}), Scalingo)
+        assert isinstance(Platform.detect({}), Unknown)
 
-    @pytest.mark.parametrize(
-        "container_id",
-        ["web.2", "worker.8", "custom_name.15", "web-2", "worker-8", "tcp-2"],
-    )
-    def test_is_redundant_instance(self, container_id):
-        assert RuntimeContainer(container_id).is_redundant_instance
+    def test_treats_only_ordinals_beyond_the_first_as_redundant(self):
+        assert not Heroku("web.1").is_redundant_instance
+        assert not Heroku("custom_name.1").is_redundant_instance
+        assert Heroku("web.2").is_redundant_instance
+        assert Heroku("custom_name.15").is_redundant_instance
+        assert not Scalingo("web-1").is_redundant_instance
+        assert not Scalingo("tcp-1").is_redundant_instance
+        assert Scalingo("web-2").is_redundant_instance
+        assert Scalingo("tcp-2").is_redundant_instance
+        # No 3-digit cap — formations with 1000+ instances are still redundant.
+        assert Heroku("web.1000").is_redundant_instance
+        assert Scalingo("worker-1024").is_redundant_instance
 
-    @pytest.mark.parametrize(
-        "container_id",
-        [
-            "5497f74465-m5wwr",
-            "a8880ee042bc4db3ba878dce65b769b6-2750272591",
-            "abcdef-2750272591",
-            "5c686f7df6-kb6kj",  # realistic Render container id
-            "5c686f7df6-2dptk",  # Render id with a digit-leading suffix
-        ],
-    )
-    def test_opaque_container_ids_are_not_redundant(self, container_id):
-        assert not RuntimeContainer(container_id).is_redundant_instance
+    def test_never_treats_opaque_id_platforms_as_redundant(self):
+        assert not Render(
+            "5497f74465-m5wwr", service_id="srv-x"
+        ).is_redundant_instance
+        # Realistic Render container id with a digit-leading suffix.
+        assert not Render(
+            "srv-x-5c686f7df6-2dptk", service_id="srv-x"
+        ).is_redundant_instance
+        assert not Ecs(
+            "a8880ee042bc4db3ba878dce65b769b6-2750272591"
+        ).is_redundant_instance
+        assert not Fly("683d924b322418").is_redundant_instance
+        assert not Railway(
+            "f9c88b6e-0e96-46f2-9884-ece3bf53d009"
+        ).is_redundant_instance
+        assert not Custom("abcdef-2750272591").is_redundant_instance
+        assert not Unknown("").is_redundant_instance
 
-    def test_is_release_instance(self):
-        container = RuntimeContainer("release.1")
-        assert container.is_release_instance
+    def test_only_heroku_release_dynos_are_release_instances(self):
+        assert Heroku("release.1").is_release_instance
+        assert Heroku("release.2").is_release_instance
+        assert not Heroku("web.1").is_release_instance
+        assert not Scalingo("web-1").is_release_instance
+        assert not Unknown("").is_release_instance
 
-    def test_is_release_instance_2(self):
-        container = RuntimeContainer("release.2")
-        assert container.is_release_instance
+    def test_strips_the_service_id_prefix_from_the_render_instance_id(self):
+        assert (
+            Render("srv-x-5497f74465-m5wwr", service_id="srv-x").container
+            == "5497f74465-m5wwr"
+        )
 
-    def test_string_representation(self):
-        container = RuntimeContainer("web.1")
-        assert str(container) == "web.1"
+    def test_lets_legacy_render_services_derive_the_api_url_from_the_service_id(self):
+        assert (
+            Render("abc", service_id="srv-x").default_api_base_url
+            == "https://adapter.judoscale.com/api/srv-x"
+        )
+        assert Heroku("web.1").default_api_base_url is None
+
+    def test_container_is_stringified(self):
+        assert Heroku("web.1").container == "web.1"
 
 
 class TestRedisHelper:


### PR DESCRIPTION
## Summary
Ports [judoscale/judoscale-ruby#275](https://github.com/judoscale/judoscale-ruby/pull/275).

- Replace the string-based `RuntimeContainer` with a `Platform` hierarchy detected from the environment, so platform-specific behavior lives on the classes that actually have those concepts instead of being re-derived from container id shape.
- Heroku and Scalingo own ordinal redundancy detection; opaque-id platforms (Render, ECS, Fly, Railway, etc.) default to non-redundant. Render also strips the service-id prefix and supplies a legacy `default_api_base_url` when `JUDOSCALE_URL` is unset.
- Call sites switch from `RUNTIME_CONTAINER` to `config["PLATFORM"]`; the reported `container` JSON key is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches metric reporting enablement (release/redundant instances) and legacy Render API URL derivation; behavior is intended to match prior logic with clearer platform boundaries and expanded ordinal tests.
> 
> **Overview**
> Replaces the string-based **`RuntimeContainer`** with a **`Platform`** hierarchy detected via **`Platform.detect(env)`**, so Heroku/Scalingo ordinal redundancy, Heroku release dynos, and Render legacy API URL behavior live on platform subclasses instead of regex on container id shape.
> 
> **`Config`** now stores **`PLATFORM`** (not **`RUNTIME_CONTAINER`**), delegates env parsing to **`Platform.detect`**, and fills **`API_BASE_URL`** from **`platform.default_api_base_url`** when **`JUDOSCALE_URL`** is unset. **Reporter** and **job metrics collectors** read **`config["PLATFORM"]`** for release skip, redundant-instance skip, and report **`container`** (unchanged JSON key). Ordinal matching no longer caps at three digits (e.g. **`web.1000`** is redundant).
> 
> Tests and sample apps updated; **`TestPlatform`** replaces **`TestRuntimeContainer`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe11aca6a23d5c87d91685245427d0f02477681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->